### PR TITLE
Motion angående ändrande av Konglig Fenixordens valdatum

### DIFF
--- a/reglemente.tex
+++ b/reglemente.tex
@@ -443,7 +443,7 @@ Att en gång varje år försöka uppnå upplösning av nämnden, och att däreft
 
 \subsubsection{Organisation}
 
-Ordförande för Fenixorden väljs på Revisions SM. Övriga medlemmar är intresserade sektionsmedlemmar.
+Ordförande för Fenixorden väljs på Glögg-SM. Övriga medlemmar är intresserade sektionsmedlemmar.
 
 \subsubsection{Verksamhet}
 


### PR DESCRIPTION
Revisions-SM 2012-03-22 punkt 8.8.

Simon Ström föredrog motionen, se bilaga.
Rättning av första att-satsen från "order" till "ordet".
Niclas Nilsson föredrog motionssvaret.

SM beslutade
- att bifalla motionen i sin helhet.
