### PR TITLE
Motion angående Kassör Emeritus

### DIFF
--- a/reglemente.tex
+++ b/reglemente.tex
@@ -970,7 +970,8 @@ D-rektoratet utnämner mottagare av Hedersdeltat, vilka presenteras vid Revision
 \subsection{Ordnar}
 
 Sektionen har fyra ordnar benämnda ``Klubbmästare Emeritus``,
-``Konglig Öfverdrif Emeritus``, ``Storasyskon Emeritus`` och ``Ordförande Emeritus``.
+``Konglig Öfverdrif Emeritus``, ``Storasyskon Emeritus``, ``Ordförande
+Emeritus`` och ``Kassör Emeritus``.
 
 \subsubsection{Ordförande Emeritus}
 
@@ -994,6 +995,11 @@ Konglig Öfverdrif Emeritus tilldelas de Konglig Öfverdrif som förtjänstfullt
 \subsubsection{Storasyskon Emeritus}
 
 Storasyskon Emeritus tilldelas de Storasyskon som förtjänstfullt arbetat under en hel mandatperiod.
+
+\subsubsection{Kassör Emeritus}
+
+Kassör Emeritus tilldelas de sektionskassörer som förtjänstfullt arbetat under en hel mandatperiod.
+Vidare gäller att Kassör Emeriti erhåller evigt kostnadsfritt medlemskap i sektionen som Alumnimedlem.
 
 \subsection{Funktionärsmedalj}
 


### PR DESCRIPTION
Revisions-SM 2012-03-22 punkt 8.17.

Max Nordlund var ej närvarande så Andreas Tarandi föredrog motionen, se bilaga.
Victor Koronen föredrog motionssvaret, se bilaga.

SM beslutade
- att avslå motionen i sin helhet.
