### PR TITLE
Motion angående Ekonomiansvariga som Dfunk

### DIFF
--- a/reglemente.tex
+++ b/reglemente.tex
@@ -702,6 +702,17 @@ Valberedaren är även ansvarig för att valen av sektionsordförande, vice sekt
 
 Vid urnval ska valurnan hållas tillgänglig för sektionens medlemmar i sektionslokalen eller annan likvärdig plats under minst fem läsdagar. Urnan skall finnas tillgänglig åtminstone en timme per dag, i första hand under lunchtid.
 
+\subsubsection{Ekonomimästare}
+
+Ekonomimästarens uppgift är att sköta DKM:s ekonomi och tillsammans med DKM sköta dess bokföring.
+Väljs på Val-SM. Har läsår som mandatperiod.
+
+\subsubsection{Ekonomeriet}
+
+Ekonomeriets uppgift är att sköta Mottagningens ekonomi och bokföring.
+Det består av två Ekonomerister. Väljs på Glögg-SM.
+Har två verksamhetsår som mandatperiod.
+
 \section{Externa representanter}
 
 \subsection{Representation i råd på THS}


### PR DESCRIPTION
Revisions-SM 2012-03-22 punkt 8.18.

Max Nordlund var ej närvarande så Andreas Tarandi föredrog motionen, se bilaga.
Victor Koronen föredrog motionssvaret, se bilaga.

SM beslutade
- att avslå motionen i sin helhet.
