### PR TITLE
Motion angående Skattmästare

### DIFF
--- a/reglemente.tex
+++ b/reglemente.tex
@@ -1005,6 +1005,12 @@ Funktionärsmedaljen utdelas till de sektionsmedlemmar som förtjänstfullt unde
 
 Endast en medalj per person och år, oavsett antal funktionärsposter personen besuttit. D-rektoratet ansvarar för att medaljen utdelas på Vårbalen eller motsvarande högtidligt tillfälle samma år.
 
+\subsection{Bokslutsmedalj}
+
+\subsubsection{Syfte}
+
+Bokslutsmedaljen utdelas till de sektionsmedlemmar som i stor utsträckning har bidragit till ett bokslut.
+
 \section{Sektionslokalen}
 
 Sektionslokalen kan endast bokas/hyras av sektionernas styrelser, nämnder och funktionärer, såväl som av organ inom THS, kårföreningar och andra sektioner. Beslut om att bevilja eller avslå bokningsbegäran fattas av sektionslokalsansvariga från fall till fall.


### PR DESCRIPTION
Revisions-SM 2012-03-22 punkt 8.19.

Max Nordlund var ej närvarande så Andreas Tarandi föredrog motionen, se bilaga.
Petter Djupfeldt föredrog motionssvaret, se bilaga.

SM beslutade
- att avslå motionen i sin helhet.
