### PR TITLE
Motion angående kreditering av Konglig Datasektionens hemliga arbetshästar och omorganisation av dess nämnder

### DIFF
--- a/reglemente.tex
+++ b/reglemente.tex
@@ -116,8 +116,77 @@ sektionens medlemmar.
 \subsubsection{Organisation}
 
 Ior leds av informationsansvarige, internt benämnd Chefsåsnan. Övriga medlemmar
-är samtliga intresserade sektionsmedlemmar. Bland dessa utses en
-systemadministratör med huvudansvar för underhåll av sektionens datorresurser.
+är intresserade sektionsmedlemmar.
+
+\paragraph{Utskott}
+
+\subparagraph{Hackeriet}
+
+Hackeriet leds av Webmaster och ska arbeta för att sprida intresse och kunskap
+om systemutveckling på datasektionen. Övriga medlemmar är intresserade
+sektionsmedlemmar.
+
+Hackeriet ska även i samarbete med övriga funktionärer och utskott inom
+informationsorganet utveckla och underhålla sektionens digitala resurser.
+
+\subparagraph{Redaqtionen}
+
+Redaqtionen leds av chefsredaqteuren och ska arbeta för att sektionstidingen
+dBuggen skrivs och utges med lämpliga intervall. Övriga medlemmar är
+intresserade sektionsmedlemmar. Chefredaqteuren benämns av tradition som Che
+Fred.
+
+Redaqtionen ska även varje år uppdatera och utge n0lledbuggen i samarbete med
+mottagningen.
+
+Redaqtionen ska även vid jubileumsår skriva och utge jubileumsdbuggen i
+samarbete med jubileumsansvariga om sådana valts av sektionsmötet.
+
+Redaqtionen ska även bistå informationsorganet och vid begäran övriga
+sektionsorgan med sin skrivskicklighet, och ska bistå Hackeriet med att skriva
+och uppdatera textmaterial på sektionens webresurser.
+
+\subparagraph{Tag Monkeys}
+
+Tag Monkeys leds av Art Director och ska arbeta för spridandet av intresse och
+förståelse för grafiska och estetiska medier på datasektionen. Övriga medlemmar
+är intresserade sektionsmedlemmar.
+
+Tag Monkeys ska på begäran av annat sektionsorgan bistå vid grafisk design.
+
+Tag Monkeys ansvarar för att sektionens grafiska profil underhålls och vid
+behov utvecklas.
+
+\paragraph{Nämndfunktionärer}
+
+\subparagraph{Webmaster}
+
+Webmaster ansvarar för att leda hackeriet i deras arbete med sektionens
+digitala resurser och att samordna detta med informationsansvarige.
+
+Har gemensam mandatperiod med infomationsansvarig.
+
+\subparagraph{Chefredaqteuren}
+
+Chefredaqteuren är ansvarig för att tidingen dBuggen utges enligt reglementets
+föreskrifter och att redaqtionen fyller den med lämpligt innehåll.
+
+Har gemensam mandatperiod med infomationsansvarig.
+
+\subparagraph{Art Director}
+
+Art Director är ansvarig för att leda Tag Monkeys i deras arbete och uppgifter.
+
+Har gemensam mandatperiod med informationsansvarig.
+
+\subparagraph{Systemansvarig}
+
+Systemansvarig ansvarar för underhåll, utveckling och uppdatering av sektionens
+servrar och hårdvarunära resurser.
+
+Systemansvarigs mandatperiod sträcker sig tills denne har utbildat en villig
+efterträdare eller efter överenskommerlse med D-rektoratet och
+informationsansvarig.
 
 \subsubsection{Verksamhet}
 
@@ -127,34 +196,6 @@ Ior skall
   \item Hjälpa D-rektoratet och övriga nämnder med informationsspridning
   \item Underhålla och utveckla sektionens webbplats
   \item Ansvara för drift och underhåll av sektionens datorresurser.
-\end{itemize}
-
-\subsection{Internationella Utskottet}
-
-\subsubsection{Ändamål}
-
-Internationella Utskottet, kallat DIU, skall verka för att främja
-internationellt utbyte på sektionen och ansvarar för mottagningen av utländska
-studenter.
-
-\subsubsection{Organisation}
-
-DIU leds av DIU:s ordförande, som till sin hjälp har DIU:s vice ordförande.
-Övriga medlemmar är samtliga intresserade sektionsmedlemmar.
-
-\subsubsection{Verksamhet}
-
-DIU skall
-
-\begin{itemize}
-  \item Samordna sektionens internationella verksamhet. Detta inkluderar att
-    hålla kontakten med ISS ordförande på THS och de ansvariga för
-    utbytesstudier på CSC:s kansli och institutionerna
-  \item Hålla sektionsmedlemmarna informerade om internationell verksamhet på
-    sektionen
-  \item Genomföra mottagningsverksamhet för utländska studenter. Detta
-    inkluderar att rekrytera faddrar och koordinera fadderverksamheten
-  \item Fungera som kontaktperson för utländska studenter på sektionen.
 \end{itemize}
 
 \subsection{Jämlikhetsnämnden}
@@ -197,6 +238,28 @@ sektionens medlemmar och i vissa fall även deras eventuella vänner.
 \subsubsection{Organisation}
 
 DKM leds av klubbmästaren. Övriga medlemmar utses av DKM.
+
+\paragraph{Nämndfunktionärer}
+
+\subparagraph{Vice klubbmästare}
+
+Vice klubbmästare ska bistå klubbmästaren i dennes uppgifter och skyldigheter.
+Har gemensam mandatperiod med klubbmästare.
+
+\subparagraph{Barmästare}
+
+Barmästaren ansvarar för inköp och utveckling av klubbmästeriets
+dryckessortiment. Har gemensam mandatperiod med klubbmästare.
+
+\subparagraph{Infomästare}
+
+Infomästare ansvarar för spridandet av information om klubbmästeriets evenemang
+och tillställningar. Har gemensam mandatperiod med klubbmästare.
+
+\subparagraph{Ekonomimästare}
+
+Ekonomimästare ansvarar för bokföring och budgetering av klubbmästeriets
+ekonomiska transaktioner. Har gemensam mandatperiod med klubbmästare.
 
 \subsubsection{Verksamhet}
 
@@ -252,6 +315,58 @@ Utöver vad som ovan angivits får presidiet besluta om eventuella undergrupper
 till de olika grenarna, externa arbetsgrupper eller i övrigt andra befattningar
 knutna till Mottagningen, samt hur dessa i så fall skall utses.
 
+\paragraph{Utskott}
+
+\subparagraph{Datas internationella utskott}
+
+Datas internationella utskott leds av datas internationella utskotts
+ordförande, internt benämnd internationalen. Övriga medlemmar är intresserade
+sektionsmedlemmar. Datas internationella utskott arbetar självständigt från
+övriga delar av mottagningen.
+
+Datas internationella utskott ska arbeta självständigt och i samarbete med THS
+internationella mottagning för välkomnandet och integrationen av
+internationella studenter läsandes kurser och program relaterade till
+datateknikprogrammet.
+
+\paragraph{Nämndfunktionärer}
+
+\subparagraph{Halvsyskon}
+
+Benämnd halvsyster eller halvbror. Bistå storasyskon i dess uppgifter och
+ansvar. Del av titel.
+
+\subparagraph{Lillasyskon}
+
+Benämnd Lillasyster eller Lillebror. Bistå storasyskon i dess uppgifter och
+ansvar. Del av titel.
+
+\subparagraph{Mamma}
+
+Bistå storasyskon i dess uppgifter och ansvar. Del av titel.
+
+\subparagraph{Konglig Indrif}
+
+Bistå Konglig Öfverdrif i dess uppgifter och ansvar. Del av titel.
+
+\subparagraph{Konglig Direktifdrif}
+
+Bistå Konglig Öfverdrif i dess uppgifter och ansvar. Del av titel.
+
+\subparagraph{Samdoquise}
+
+Bistå titel i foto-, film-, ljud-, och ljusrelaterade frågor.
+
+\subparagraph{Uber-ekonomerist}
+
+Bistå övriga mottagningen i ekonomiska frågor som budgetering och bokföring.
+
+\subparagraph{Datas internationella utskotts ordförande}
+
+Ska uppmuntra och motivera för engagemang i datas internationella utskotts
+verksamhet och i THS internationella mottagning. Inte nödvädigtvis en del av
+sektionens centrala mottagning.
+
 \subsubsection{Rekrytering till Mottagningen}
 
 Titelgruppen skall utlysa platserna i höstens mottagning under våren. Alla
@@ -299,6 +414,13 @@ samt att inbringa sponsorpengar till sektionen.
 Näringslivsgruppen leds av Näringslivsansvarig. Övriga medlemmar är samtliga
 intresserade sektionsmedlemmar.
 
+\paragraph{Nämndfunktionärer}
+
+\subparagraph{Vice näringslivsansvarig}
+
+Vice näringslivsansvarig ska bistå näringslivsansvarig i dennes uppgifter och
+skyldigheter. Har gemensam mandatperiod med näringslivsansvarig.
+
 \subsubsection{Verksamhet}
 
 Näringslivsgruppen skall
@@ -327,8 +449,43 @@ rikt kulturutbud för sektionens medlemmar.
 
 \subsubsection{Organisation}
 
-QN leds av Qulturattachén. Övriga medlemmar är intresserade sektionsmedlemmar
-som har jobbat på minst ett QN-arrangemang.
+QN leds av Qulturattachén. Övriga medlemmar är intresserade sektionsmedlemmar.
+
+\paragraph{Utskott}
+
+\subparagraph{Filmgruppen}
+
+Filmgruppen leds av Filmansvarig och ska arbeta för att sprida intresse och
+kunskap om film, filmkultur och filmskapande på sektionen. Övriga medlemmar är
+intresserade sektionsmedlemmar.
+
+Filmgruppen ska med regelbundna mellanrum och med övriga qulturnämnden till
+hjälp anordna filmkvällar och andra filmrelaterade evenemang för sektionen.
+
+\subparagraph{Filmgruppen}
+
+Spelgruppen leds av Spelansvarig och ska arbeta för att sprida intresse om och
+tillfällen för sällskapspel på datasektionen.
+
+Spelgruppen ska med jämna regelbundna mellanrum och med övriga qulturnämnden
+till hjälp anordna spelkvällar och andra sällskapspelsrelaterade evenemang på
+datasektionen.
+
+\paragraph{Nämndfunktionärer}
+
+\subparagraph{Filmansvarig}
+
+Anvarig för organisationen av filmrelaterade evenemang samt att motivera och
+uppmuntra till sektionsmedlemmars engagemang inom filmgruppen. Har gemensam
+mandatperiod med nämndordförande eller efter gemensamt beslut med
+nämndordförande och D-rektoratet.
+
+\subparagraph{Spelansvarig}
+
+Anvarig för organisationen av spelrelaterade evenemang samt att motivera och
+uppmuntra till sektionsmedlemmars engagemang inom spelgruppen. Har gemensam
+mandatperiod med nämndordförande eller efter gemensamt beslut med
+nämndordförande och D-rektoratet.
 
 \subsubsection{Verksamhet}
 
@@ -345,44 +502,6 @@ QN bör
     annat som man anser är ett gott exempel på god qultur. Q-märkningen skall
     förevigas exempelvis i form av ett tygmärke.
 \end{itemize}
-
-\subsection{Redaqtionen}
-
-\subsubsection{Ändamål}
-
-Redaqtionen ansvarar för att sektionens tidning dBuggen utkommer med ett lagom
-antal nummer varje läsår, samt att nØlledBuggen utkommer med exakt ett nummer
-inför Mottagningen varje läsår.
-
-\subsubsection{Organisation}
-
-Redaqtionens arbete leds av Chefredaqteuren, Che Fred. Övriga medlemmar är
-samtliga intresserade sektionsmedlemmar.
-
-\subsubsection{Verksamhet}
-
-\paragraph{dBuggen}
-
-dBuggens innehåll och inriktning bestäms av sektionens medlemmar genom deras
-val av Chefredaqteur. Av tradition utkommer exakt ett nummer av dBuggen klockan
-kvart i fem.
-
-\paragraph{nØlledBuggen}
-
-nØlledBuggens innehåll skall bestå av gammalt material som tidigare publicerats
-i dBuggen, information rörande Mottagningen, allmän information om sektionens
-olika delar, samt övrigt material som Chefredaqteuren finner lämpligt.
-
-\paragraph{Annonser}
-
-Alla världsliga detaljer rörande försäljning av annonser i dBuggen och
-nØlledBuggen sköts av Näringslivsgruppen. Redaqtionen ansvarar endast för att
-införa beställda annonser och ge dessa en studentikos framtoning.
-
-\paragraph{Pris}
-
-Priset för ett exemplar av dBuggen eller nØlledBuggen skall vara noll
-prisbasbelopp.
 
 \subsection{Spexmästeriet}
 
@@ -597,24 +716,14 @@ Väljs på Val-SM. Har läsår som mandatperiod.
 
 \subsection{Nämndordförande}
 
-\subsubsection{Chefredaqteur}
-
-Är ordförande för Redaqtionen. Ser till att ett lagom antal vanliga nummer av
-dBuggen, plus exakt ett nummer av nØlledBuggen utkommer varje år.
-
-Väljs på Glögg-SM. Har kalenderår som mandatperiod.
-
 \subsubsection{Informationsansvarig}
 
-Är ordförande för Informationsorganet.
+Är ordförande för Informationsorganet. Ansvarar för att samordna
+informationsorganets utskott samt att efter behov utveckla och förnya nämndens
+verksamhet. Ansvarar även för att vid behov uppdatera sektionens
+informationsspridningsguidelines.
 
 Väljs på Val-SM. Har läsår som mandatperiod.
-
-\subsubsection{Internationella Utskottets ordförande}
-
-Främjar internationellt utbyte på sektionen.
-
-Väljs på Glögg-SM. Har kalenderår som mandatperiod.
 
 \subsubsection{Jämlikhetsnämndens ordförande}
 
@@ -649,7 +758,9 @@ Väljs på Glögg-SM. Har kalenderår som mandatperiod.
 
 \subsubsection{Qulturattaché}
 
-Är ordförande för Qulturnämnden.
+Är ordförande för Qulturnämnden. Ansvarar för att samordna qulturnämndens
+utskott samt att löpande och efter behov utveckla och förnya nämndens
+qulturella aktiviteter.
 
 Väljs på Val-SM. Har läsår som mandatperiod.
 
@@ -691,7 +802,7 @@ Väljs på Val-SM. Har läsår som mandatperiod.
 
 Väljs på Val-SM. Har läsår som mandatperiod.
 
-\subsection{Övriga funktionärer}
+\subsection{Övriga sektionsfunktionärer}
 
 \subsubsection{Fanbärare}
 
@@ -872,8 +983,8 @@ tillhanda tillsammans med bokföringen.
 \paragraph{Mandatperiod}
 
 Revisorn väljs på Glögg SM till sakrevisor för sektionen under ett
-verksamhetsår samt till funktionärsposten revisor under perioden 1 januari till
-30 juni nästkommande år.
+verksamhetsår samt till sektionsfunktionärsposten revisor under perioden 1
+januari till 30 juni nästkommande år.
 
 \subsubsection{Sektionshistoriker}
 
@@ -909,8 +1020,8 @@ intervjuerna skall göras tillgängligt för sektionens medlemmar på lämpligt 
 senast samma dag som en nominering senast skall bekräftas enligt sektionens
 stadgar \S5.2.4.
 
-Nominering till funktionärspost skall delgivas kandidaten senast 3 läsdagar
-före det SM där valet sker.
+Nominering till sektionsfunktionärspost skall delgivas kandidaten senast 3
+läsdagar före det SM där valet sker.
 
 \paragraph{Skyldigheter}
 
@@ -1164,7 +1275,7 @@ SM.
           \item Ledamot för studiemiljöfrågor
           \item Ledamot för utbildningsfrågor
       \end{enumerate}
-      \item Övriga funktionärer
+      \item Övriga sektionsfunktionärer
       \begin{enumerate}
           \item DIU
           \item DKM
@@ -1262,7 +1373,7 @@ en hel mandatperiod.
 \subsubsection{Syfte}
 
 Funktionärsmedaljen utdelas till de sektionsmedlemmar som förtjänstfullt under
-en hel mandatperiod tjänstgjort som funktionär på sektionen.
+en hel mandatperiod tjänstgjort som sektionsfunktionär på sektionen.
 
 \subsubsection{Utdelning}
 

--- a/stadgar.tex
+++ b/stadgar.tex
@@ -201,7 +201,7 @@ Det åligger SM
     ekonomiska redovisning
   \item att ta ställning till ansvarsfrihet för D-rektoratet
   \item att om sektionsmedlem så önskar granska protokoll från DM
-  \item att välja funktionärer, med undantag av de som väljs vid urnval
+  \item att välja sektionsfunktionärer, med undantag av de som väljs vid urnval
   \item att genomföra fyllnadsval vid behov, även till poster som vanligen
     väljs vid urnval
 \end{itemize}
@@ -362,8 +362,7 @@ Det åligger D-rektoratet
   \item att verkställa av SM fattade beslut
   \item att i brådskande fall utöva SM:s befogenheter. Sådant fall skall dock
     alltid prövas på nästkommande SM
-  \item att efter skriftlig begäran från en av SM vald funktionär entlediga
-    densamme
+  \item att efter skriftlig begäran från funktionär entlediga densamme
   \item att vid behov och efter majoritetsbeslut vid DM tillförordna
     intresserad sektionsmedlem till vakant post inom sektionen. D-rektoratet
     får dock ej tillförordna D-rektoratsledamot, sektionsrevisor, ledamot eller
@@ -423,9 +422,18 @@ En nämnds sammansättning och verksamhet regleras i reglementet.
 
 \paragraph{Ordförande}
 
-För varje nämnd skall det finnas en eller flera funktionärer som är ordförande.
-Nämndens ordförande är ansvarig för nämndens verksamhet samt att dess
-reglemente hålls aktuellt.
+För varje nämnd skall det finnas en eller flera sektionsfunktionärer som är
+ordförande. Nämndens ordförande är ansvarig för nämndens verksamhet samt att
+dess reglemente hålls aktuellt.
+
+\paragraph{Utskott}
+
+En nämnd kan delvis eller fullständigt bestå av ett eller flera utskott.
+Utskottens förekomst, sammansättning och verksamhet regleras i reglementet.
+
+\subparagraph{Ordförande}
+
+För varje utskott ska det finnas en nämndfunktionär som är ordförande.
 
 \subsubsection{Skyldigheter}
 
@@ -440,24 +448,58 @@ mottagningsnämnd.
 
 \subsection{Funktionärer}
 
-\subsubsection{Ändamål}
+\subsubsection{Sektionsfunktionärer}
 
-Funktionär är den som av SM eller vid urnval har valts till ett
+\paragraph{Ändamål}
+
+Sektionsfunktionär är den som av SM eller vid urnval har valts till ett
 förtroendeuppdrag. En funktionärs verksamhet och uppdrag regleras i
 reglementet.
 
-\subsubsection{Skyldigheter}
+\paragraph{Skyldigheter}
 
-Funktionär ansvarar för sitt verksamhetsområde samt för att funktionärens del
-av reglementet hålls aktuellt. Funktionär är skyldig att löpande hålla
-D-rektoratet informerat om sitt verksamhetsområde, samt att på anmodan från
-D-rektoratet eller SM fullständigt redovisa sin verksamhet för densamme.
+Sektionsfunktionär ansvarar för sitt verksamhetsområde samt för att
+sektionsfunktionärens del av reglementet hålls aktuellt. Sektionsfunktionär är
+skyldig att löpande hålla D-rektoratet informerat om sitt verksamhetsområde,
+samt att på anmodan från D-rektoratet eller SM fullständigt redovisa sin
+verksamhet för densamme.
 
-\subsubsection{Mandatperiod}
+\paragraph{Mandatperiod}
 
-Funktionärs mandatperiod sammanfaller med verksamhetsår om inget annat är
-föreskrivet i reglementet. Ordinarie val skall hållas på mandatperiodens sista
-ordinarie SM.
+Sektionsfunktionärs mandatperiod sammanfaller med verksamhetsår om inget annat
+är föreskrivet i reglementet. Ordinarie val skall hållas på mandatperiodens
+sista ordinarie SM.
+
+\subsubsection{Nämndfunktionärer}
+
+\paragraph{Ändamål}
+
+Nämndfunktionär är den som av nämndordförande utsetts till en av reglementet
+definierad nämndfunktionärspost.
+
+\paragraph{Skyldigheter}
+
+En nämndfunktionärs ansvar regleras av reglementet.
+
+\paragraph{Tillsättning}
+
+En nämndfunktionär tillsätts av nämndens ordförande i samråd med D-rektoratet.
+Tillsättningar av nämndfunktionärsposter ska meddelas på nästa sektionsmöte.
+
+\subparagraph{Ifrågasättning}
+
+Om tre nämndmedlemmar, sakrevisorer eller nämndordförande begär hos
+D-rektoratet ska val av nämndfunktionärspost istället hållas på nästa DM.
+
+\paragraph{Mandatperiod}
+
+Nämndfunktionärs mandatperiod sammanfaller med nämndordförandes om inget annat
+föreskrivs i reglementet.
+
+\paragraph{Avsättning}
+
+Nämndordförande har rätt att med godkännande av D-rektoratet. Avsättning av
+Nämndfunktionär ska meddelas på nästa SM.
 
 \subsubsection{Valberedning}
 


### PR DESCRIPTION
Val-SM 2012-05-03 punkt 8.8.

Erik Lindström, Marie Alexander och Martin Frost föredrog motionen, se bilaga.
Peter Boström föredrog motionssvaret, se bilaga.
Christian Avemark yrkade om streck i debatten.

SM beslutade
- att bifall av streck i debatten.

Erik Lindström, Marie Alexander och Martin Frost drog tillbaka motionen.
