### PR TITLE
Motion angående Fenixorden... ...igen.

### DIFF
--- a/reglemente.tex
+++ b/reglemente.tex
@@ -486,8 +486,7 @@ verka för nämndes samtidiga återinstiftande.
 
 \subsubsection{Organisation}
 
-Ordförande för Fenixorden väljs på Glögg-SM. Övriga medlemmar är intresserade
-sektionsmedlemmar.
+Leds av Fenixordens ordförande. Övriga medlemmar bestäms av nämndordförande.
 
 \subsubsection{Verksamhet}
 
@@ -929,6 +928,12 @@ Vid urnval ska valurnan hållas tillgänglig för sektionens medlemmar i
 sektionslokalen eller annan likvärdig plats under minst fem läsdagar. Urnan
 skall finnas tillgänglig åtminstone en timme per dag, i första hand under
 lunchtid.
+
+\subsubsection{Fenixordens Orförande}
+
+Är ordförande för Fenixorden.
+
+Väljs på Glögg-SM. Har läsår som mandatperiod.
 
 \section{Externa representanter}
 


### PR DESCRIPTION
Val-SM 2012-05-03 punkt 8.5.

Erik Lindström föredrog motionen, se bilaga.
Petter Djupfeldt föredrog motionssvaret, se bilaga.
Frida Jansson lämnade yrkandet
- att andra att-satsen ändras till att en paragraf Fenixordens Ordförande förs in i sektionens
  reglemente under paragraf 3.2 Nämndordförande med följande lydelse, se bilaga.
  - 3.2.16 Fenixordens ordförande Är ordförande för Fenixorden. Väljs på Glögg-SM. Har kalenderår som mandatperiod.

SM beslutade
- att bifall av motionen i sin helhet.
