### PR TITLE
Proposition angående funkismedaljerna

### DIFF
--- a/reglemente.tex
+++ b/reglemente.tex
@@ -1266,9 +1266,10 @@ en hel mandatperiod tjänstgjort som funktionär på sektionen.
 
 \subsubsection{Utdelning}
 
-Endast en medalj per person och år, oavsett antal funktionärsposter personen
-besuttit. D-rektoratet ansvarar för att medaljen utdelas på Vårbalen eller
-motsvarande högtidligt tillfälle samma år.
+Endast en medalj per person och mandatperiod. I de fall då en funktionär
+besuttit fler än en funktionärspost under en mandatperiod ska alla dessa
+omnämnas på samma medalj. D-rektoratet ansvarar för att medaljen utdelas på
+Vårbalen eller motsvarande högtidligt tillfälle samma år.
 
 \subsection{Projektledarmedalj}
 


### PR DESCRIPTION
Val-SM 2012-05-03 punkt 7.2.

Andreas Johansson föredrog propositionen, se bilaga.
David Karlbom lämnade yrkandet 
- att paragraf 6.3.2 i reglementet byts ut mot "Endast en medalj per funktionärspost och man-
  datperiod. D-rektoratet ansvarar för att medaljen utdelas på Vårbalen eller motsvarande
  högtidligt tillfälle samma år.", se bilaga.

D-rektoratet jämkar sig med David Karlboms yrkande.

SM beslutade
- att bifalla propostionen i sin helhet.
