### PR TITLE
Laga byggprocessen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-LATEX=xelatex
+LATEX?=pdflatex
 RUBY=ruby
 
 .PHONY: default pdf distclean clean

--- a/alkoholpolicy.tex
+++ b/alkoholpolicy.tex
@@ -2,6 +2,7 @@
 
 \usepackage[swedish]{babel}
 \usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
 
 \usepackage{hyperref}
 
@@ -17,7 +18,7 @@ THS har en alkohol- och drogpolicy som fastställs av Kårfullmäktige och gäll
 inom hela THS organisation, Datasektionen inkluderad. Detta dokument ska ses
 som ett tillägg till THS alkohol- och drogpolicy.
 
-I de fall detta dokument står i konﬂikt med Sveriges rikes lag, THS alkohol-
+I de fall detta dokument står i konflikt med Sveriges rikes lag, THS alkohol-
 och drogpolicy, eller andra av KTH eller THS uppsatta regler är detta dokument
 underordnat.
 

--- a/ekonomiskt_styrdokument.tex
+++ b/ekonomiskt_styrdokument.tex
@@ -2,6 +2,7 @@
 
 \usepackage[swedish]{babel}
 \usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
 
 \usepackage{hyperref}
 

--- a/stadgar.tex
+++ b/stadgar.tex
@@ -2,6 +2,7 @@
 
 \usepackage[swedish]{babel}
 \usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
 
 \usepackage{hyperref}
 


### PR DESCRIPTION
Sen a010c657d811b394c014be0de2d721a4d812ee16 går styrdokumenten inte längre att bygga med hjälp av `make`. Gissningsvis så lades paketet inputenc till i reglementet eftersom att `pdflatex` inte hanterar svenska tecken utan det.

Då `pdflatex` verkar vara mer vanligt förekommande än `xelatex` så anser jag det vara lika bra att byta tillbaka till att använda `pdflatex` i Makefile, vilket kräver att inputenc inkluderas i resterande styrdokument.
