### PR TITLE
Ändringar gjorda enligt beslut tagna på Revisions-SM 3 mars 2015.

### DIFF
--- a/reglemente.tex
+++ b/reglemente.tex
@@ -116,16 +116,15 @@ sektionens medlemmar.
 
 \subsubsection{Organisation}
 
-Ior leds av informationsansvarige, internt benämnd Chefsåsnan. Övriga medlemmar
-är samtliga intresserade sektionsmedlemmar. Bland dessa utses en
-systemadministratör med huvudansvar för underhåll av sektionens datorresurser.
+Ior leds av Kommunikatören, internt benämnd Chefsåsnan. Övriga medlemmar
+är samtliga intresserade sektionsmedlemmar.
 
 \paragraph{Undergrupper}
 
 Informationsorganets undergrupper är delmängder av Informationsorganet
 med särskilda ansvar och uppgifter. Undergrupperna förfogar
 över sina eventuella respektive delar av informationsorganets budget
-och leds av sina respektive funktionärer i samråd med Informationsansvarige.
+och leds av sina respektive funktionärer i samråd med Kommunikatören.
 Samtliga undergrupper delar informationsorganets
 övergripande ansvar och uppgifter samt ska vara Informationsorganet
 och andra nämnder behjälpliga inom sina särskilda arbetsområden.
@@ -141,8 +140,10 @@ Redaqtionen ansvarar för skriverier, nyhetsutskick och att ge
 ut sektionstidningen dBuggen. Redaqtionen ska specifikt uppdatera
 och ge ut exakt en n0lledBuggen till varje mottagning.
 Priset för ett exemplar av dBuggen eller n0lledBuggen skall
-vara noll prisbasbelopp. Redaqtionen leds av Chefredaqteuren,
+vara noll prisbasbelopp. Redaqtionen leds av Chefredaqtören,
 internt benämnd CheFred.
+
+\subparagraph(Crash & Burn)
 
 \subsubsection{Verksamhet}
 
@@ -341,7 +342,7 @@ Näringslivsgruppen skall
 \subsubsection{Avtal}
 
 Näringslivsansvarig har rätt att förhandla fram avtal med företag och
-organisationer, men dessa måste sedan undertecknas av firmatecknare.
+organisationer. Firmatecknare har rätt att utfärda en fullmakt till Näringslivsansvarig för att hen ska kunna ingå i sagda avtal.
 
 \subsubsection{Bokföringsplikt}
 Näringslivsgruppen är bokföringspliktig.
@@ -637,24 +638,9 @@ Väljs på Val-SM. Har läsår som mandatperiod.
 
 \subsubsection{Ledamot för studiemiljöfrågor}
 
-Skall verka för en bättre studiemiljö på sektionen och fungera som sektionens
-studerandeskyddsombud.
+Skall verka för en bättre studiemiljö på sektionen.
 
 Väljs på Val-SM. Har läsår som mandatperiod.
-
-\paragraph{Studerandeskyddsombud}
-
-I rollen som studerandeskyddsombud skall ledamoten såväl proaktivt som reaktivt
-verka för att sektionsmedlemmarnas studiemiljö är så bra som möjligt. Detta
-görs bland annat genom att
-
-\begin{itemize}
-  \item ta emot och behandla anmälningar rörande studiemiljön från
-    sektionsmedlemmar
-  \item agera som informationskanal mellan sektionsmedlemmarna och KTH samt THS
-    i arbetsmiljöfrågor
-  \item närvara på skyddsronder i lokaler där sektionsmedlemmarna ofta vistas.
-\end{itemize}
 
 \subsubsection{Ledamot för utbildningsfrågor}
 
@@ -665,7 +651,7 @@ Väljs på Val-SM. Har läsår som mandatperiod.
 
 \subsection{Nämndordförande}
 
-\subsubsection{Informationsansvarig}
+\subsubsection{Kommunikatör}
 
 Är ordförande för Informationsorganet.
 
@@ -962,11 +948,40 @@ grafiska utveckling och arbete.
 
 Väljs på Val-SM. Har läsår som mandatperiod.
 
-\subsubsection{Chefredaqteur}
+\subsubsection{Chefredaqtör}
 
 \paragraph{Ändamål}
 Leder Redaqtionen. Ansvarar tillsammans med Redaqtionen för skriverier och
 nyhetsutskick inom Informationsorganet samt för sektionstidingen dBuggen.
+
+\paragraph{Mandatperiod}
+Väljs på Val-SM. Har läsår som mandatperiod.
+
+\subsubsection{Systemansvarig}
+
+\paragraph{Ändamål}
+Leder Crash & Burn. Ansvarar tillsammans med Crash & Burn över sektionens datasystem.
+
+\paragraph{Mandatperiod}
+Väljs på Val-SM. Har läsår som mandatperiod.
+
+\subsubsection{Studerandeskyddsombud}
+
+\paragraph{Ändamål}
+Har till uppgift att agera som studerandeskyddsombud för sektionen. Funktionären skall såväl proaktivt som reaktivt verka för att sektionsmedlemmarnas studiemiljö är så bra som möjligt. 
+
+\paragraph{Verksamhet}
+Studerandeskyddsombudet ska:
+\begin{itemize}
+    \item ta emot och behandla anmälningar rörande studiemiljön för sektionsmedlemmar
+    \item agera som informationskanal mellan sektionsmedlemmarna och KTH samt THS i arbetsmiljö frågor
+    \item närvara på skyddsronder i lokaler där sektionsmedlemmarna ofta vistas
+    \item se till att det finns en sjukvårdslåda med lämpligt innehåll i sektionslokalen
+    \item regelbundet kontrollera de brandsläckare som finns i sektionslokalen
+\end{itemize}
+
+\paragraph{Organisation}
+I det fall att posten är vakantsatt är Ledamot för studiemiljöfrågor ställföreträdande studerandeskyddsombud.
 
 \paragraph{Mandatperiod}
 Väljs på Val-SM. Har läsår som mandatperiod.
@@ -1042,7 +1057,7 @@ Vice sektionsordförande
 
 \paragraph{Ordinarie}
 
-Chefredaqteur
+Chefredaqtör
 
 \paragraph{Suppleant}
 


### PR DESCRIPTION
Funktionärsposterna SSO, Chefredaqtören och Kommunikatör (fd informationsansvarig och systemansvarig) samt d-Smf ändrades.