### PR TITLE
Val-SM 2016 - Prop. ang. Uppdatering av Ekonomiskt Styrdok.

### DIFF
--- a/ekonomiskt_styrdokument/body.md
+++ b/ekonomiskt_styrdokument/body.md
@@ -1,92 +1,54 @@
-Bakgrund
-========
-
+#Ekonomiskt styrdokument#
+##§1 Bakgrund##
 Detta dokument ska fylla två funktioner. Dels ska det ange de för sektionen gällande regler för hur ekonomin sköts. Dokumentet ska även fungera som en snabb utbildning i hur funktionärer och nämnder ska sköta sin ekonomi och ekonomiska redovisning.
+##§2 Bokföringsplikt##
+Bokföringspliktiga nämnder såsom DKM, Mottagningen och Prylmångleriet samt vissa projekt sköter sin egen bokföring. Bokföring skall skötas löpande med målsättningen att vara färdig senast nästföljande månadsskifte då det ej är sommarferie. Utöver denna målsättning kan kassören sätta krav på bokföringsdeadlines. Om en nämnd eller ett projekt inte håller utsatta deadlines äger D-rektoratet rätten att applicera restriktioner på dess verksamhet såsom att förbjuda bruk av sektionens alkoholtillstånd. 
+Om en nämnd eller ett projekt bokför kontinuerligt och arbetar mot tidsmålet ovan så kan nämnden/projektet belönas. Man kan få extra pengar till bokförings-MUTA/fika/teambuilding från en för ändamålet reserverad budgetpost. Bedömning av detta och utdelning av dessa pengar sker av kassör.
 
-Bokföringsplikt
-===============
+##§3 Skulder till engagerade##
+Kvitton för inköp åt sektionen skall senast lämnas in 30 dagar efter då inköpet gjordes för att skulden ska betalas tillbaka, därefter kan den nekas. Skulder ska betalas tillbaka till engagerade inom 5 veckor (ej under ferie) under förutsättning att alla uppgifter är rätt registrerade och det framgår i vilket syfte inköpet är gjort.
 
-Bokföringspliktiga nämnder så som DKM, mottagningen, Prylmångleriet samt projekt sköter sin egen bokföring. Bokföring skall skötas löpande och vara färdig senast nästföljande månadsskiftet då det ej är sommarferie. Verifikat från respektive nämnd skall använda varsin verifikatserie enligt appendix [sec:serier]. Alla transaktioner på nämndens bankkonto ska bokföras av respektive nämnd. Då transaktioner mellan två nämnders konton sker ska bara den nämnd som utfört överföringen bokföra transaktionen.
+##§4 Hantering av kontanter##
+Sektionen har en handkassa benämnd centralt, denna används av Mottagningen, DKM och sektionen i stort. Överföringar mellan handkassor bokförs av källan för överföringen. 
+Summor över 1000 kronor får inte förvaras i sektionslokalen längre än över natten och då endast i låst utrymme. Undantaget från detta är pengar som förvaras i depositionsskåpet.
+##§5 Lager##
 
-Skulder till engagerade
-=======================
+###§5.1 Förvaltning av dryckeslager###
+DKM förvaltar sektionens dryckeslager, utom under mottagningsperioden då Mottagningen tar över den uppgiften. Det innebär att det i huvudsak är de som fyller på lagren och bokför påfyllning. Sprit, vin, cider och öl som serveras vid pub­- och klubbverksamhet ska lagerföras.
+Dryckeslagren ska inventeras minst en gång varannan månad samt innan och efter mottagningsperioden. Det inventerade värdet ska synkas mot bokföringen genom av kassör särskilt anvisad resultatgrupp. Schablonbeloppen nämnda i §5.2 ska anpassas med hänsyn till att minimera differenserna i lagerföringen.
+###§5.2 Dryckeslager vid festtillfällen###
+När en nämnd eller ett projekt har fest och använder sektionens dryckeslager ska det bokföras av bokföringsansvariga för nämnden eller projektet som festen ligger under. Nämnden/projektet ska både belastas för inköp av drycken och tilldelas försäljningen av den. Kostnaden för inköpet får beräknas enligt av kassören tillhandahållna schablonbelopp. Serveringsansvarig för festtillfället är ansvarig för att betalning och dagsavslut görs efter sektionens standarder. Serveringsansvarig är även ansvarig för att eventuella handkassor hanteras enligt §4 i detta dokument. Serveringsansvarig ska i skälig tid innan festtillfället kontakta den nämnd som förvaltar dryckeslagren och informera sig om gällande bestämmelser för sektionen.
+###§5.3 Andra lager###
+Andra lager (till exempel ovvelager) ska inventeras minst en gång per år. Sådan inventering skall komma kassören till handa så snart som möjligt efter att den skett.
+##§6 Kvitton##
+Kvitto alternativt faktura ska erbjudas i någon form för all försäljning.
 
-Kvitton för inköp åt sektionen skall senast lämnas in 30 dagar efter då inköpet gjordes för att skulden ska betalas tillbaka. Skulder ska betalas tillbaka till engagerade inom 5 veckor (ej under ferie) under förutsättning att alla uppgifter är rätt registrerade och det framgår i vilket syfte inköpet är gjort.
+##§7 Fakturor##
+###§7.1 Inköp via faktura###
+Inköp på faktura betyder för det mesta att man nyttjar ett av sektionens kreditavtal. Detta får göras av sektionens funktionärer, både direkt (att funktionären nyttjar kreditavtalet) eller indirekt (att annan person nyttjar kreditavtalet på order av funktionär). Det är funktionärens ansvar att se till att det finns utrymme i budget för kostnaderna. Det går i regel bra att nyttja kreditavtal skrivna av andra organ inom sektionen än det man handlar för, men personen som gör inköpet ansvarar själv för att vara informerad om kreditavtalets gränser. 
+Stora inköp på över 50000 kr som kan komma att påverka sektionens ekonomi i stort ska meddelas kassören så fort det blir känt. Alla fakturor i sektionens namn ska skickas till sektionens gällande fakturaadress.
+###§7.2 Försäljning via faktura###
+Fakturor utställda av sektionen ska skapas genom av kassör anvisad metod. Nämnder ansvarar själva för att kontinuerligt kontrollera att utskickade fakturor betalas i tid. En kopia av fakturan ska omgående komma bokföringsansvarig tillhanda.
+##§8 Budget##
+Budgeten är ett instrument för att försöka planera och förutspå hur verksamhetsårets ekonomi kommer se ut. Budgeten ska följas i den mån som går, men om verkligheten inte tillåter detta så kan man behöva bortse från budgeten, om så sker är det bra att informera kassör omgående. 
+I den rambudget som beslutas om på SM finns posterna: Intäkter, Utgifter, Extern balans och Intern balans. Utöver detta krävs det att det för varje nämnd på SM uppvisas en detaljbudget som överensstämmer med rambudgeten. Funktionärer som handhar en detaljbudget kan i samråd med sektionsstyrelse revidera denna under eller inför ett verksamhetsår. Sådana ändringar skall redovisas på styrelsemöte (DM).
+###§8.1 Förklaring###
+Intäkter är nämndens totala intäkter under året. Utgifter är nämndens totala utgifter under året. Extern balans är balansen för de event och budgetposter som gagnar hela sektionen. Exempel på detta är sittningar hela sektionen är bjuden till, inventarier till META, pubar mm. Intern balans är balansen på event och budgetposter som gagnar en liten grupp inom sektionen, såsom styrelsen, DKM, andra nämnder med evenemang där alla inte är inbjudna. Exempel på denna typ av event och budgetposter är mat vid arbete (MUTA), teambuilding, fika, fest, bungyjump, paintball, kryssning, thailandsresa mm. Det är särskilt viktigt att denna kostnad inte överstiger budgeten. Vad som är externt och internt bedöms av instanserna i §A.
+###§8.2 Skyldighet###
+Denna frihet som ges att få forma sin egen budget kräver fortfarande att pengar läggs på rätt saker och de med rätt att betala ut utgifter har rätt att neka utbetalningen om det bryter mot detta dokument. Beslutet kan överklagas enligt nämnda ordning i §A.
+##§9 Accesser##
+Firmatecknare har tillgång till att se och hantera sektionens samtliga tillgångar och transaktioner på banken.
+Revisorer har tillgång till att se sektionens samtliga tillgångar och transaktioner på banken.
+Nämndordförande och projektledare för bokföringspliktiga nämnder och projekt ska ha tillgång till att se och hantera tillgångarna som ligger på sin egen nämnds bankkonto.
+Bokföringsansvariga utsedda av nämndordförande eller projektledare har rätt till att se tillgångar och transaktioner på nämndens/projektets bankkonto.
 
-Hantering av kontanter
-======================
+Utöver dessa bankaccesser kan D-rektoratet, genom beslut på DM, besluta om att ge andra personer tillgång till att se och/eller hantera sektionens tillgångar. Firmatecknare äger även rätten att dra in personers accesser, det ska därefter prövas på nästföljande DM.
 
-Mottagningen och DKM är i dagsläget de enda nämnder som har tillräckliga säkerhetsrutiner för att förvalta större handkassor åt sektionen, andra nämnder ska därför endast ha mindre och tillfälliga handkassor. Prylmångleriet får dock också föra en kontinuerlig handkassa. Större summor ska dock föras över till DKMs eller Mottagningens handkassor. Överföringar mellan handkassor bokförs på samma sätt som överföringar mellan bankkonton, det vill säga källan för överföringen är ansvarig för att bokföra den. Summor över 400 kronor får inte förvaras i sektionslokalen längre än över natten och då endast i låst utrymme. Endast prylmångleriet äger permanent undantag att förvara högre belopp i sektionslokalen och bedömer i samråd med D­rektoratet vilka belopp som är lämpliga att förvara där.
-
-Dryckeslager
-============
-
-Förvaltning av dryckeslager
----------------------------
-
-DKM förvaltar sektionens dryckeslager, utom under mottagningsperioden då Mottagningen tar över den uppgiften . Det innebär att det i huvudsak är dem som fyller på lagren och bokför påfyllning. Sprit, vin, cider, öloch läsk som serveras vid pub­ och klubbverksamhet ska lagerföras. DKM och Mottagningen avgör själva om de vill lagerföra barkit och övriga alkoholfria produkter.
-
-Dryckeslager vid festtillfällen
--------------------------------
-
-När en nämnd eller ett projekt har fest och använder sektionens dryckeslager så ska det bokföras av bokföringsansvariga för den serie som nämnden eller projektet ligger under. Nämnden/projektet ska både belastas för inköp av drycken och tilldelas försäljningen av den. Serveringsansvarig för festtillfället är ansvarig för att betalning och dagsavslut görs efter sektionens standarder. Serveringsansvarig är även ansvarig för att handkassor hanteras enligt [sec:kontanter] i detta dokument. Serveringsansvarig ska i skälig tid innan festtillfället kontakta den nämnd som förvaltar dryckeslagren och informera sig om gällande bestämmelser för sektionen.
-
-Kvitton
-=======
-
-Kvitton alternativt faktura ska skickas ut eller lämnas i någon form för all försäljning, då även förköpsbiljetter.
-
-Fakturor
-========
-
-Inköp via faktura
------------------
-
-Inköp på faktura betyder för det mesta att man nyttjar ett av sektionens kreditavtal. Det går i regel bra att nyttja kreditavtal skrivna av andra organ inom sektionen än det man handlar för, men personen som gör inköpet ansvarar själv för att vara informerad om avtalets gränser. Stora inköp på över 50000 kr kan komma att påverka sektionens ekonomi i stort ska meddelas kassören så fort det blir känt för sektionen. Alla fakturor i sektionens namn ska skickas till sektionens gällande fakturaadress.
-
-Försäljning via faktura
------------------------
-
-Nämnder ansvarar själva för att kontinuerligt kontrollera att utskickade fakturor betalas i tid. En kopia av fakturan ska omgående komma bokföringsansvarig tillhanda.
-
-Budget
-======
-
-Budgeten är ett instrument för att försöka förutspå framtiden och ska följas i den mån som går, men om verkligheten inte tillåter detta så måste man bortse från budgeten. I den rambudget som beslutas om på SM finns posterna: Intäkter, Utgifter, Extern kostnad och Intern kostnad. Utöver detta krävs det att det för varje nämnd på SM uppvisas en detaljbudget som överensstämmer med rambudgeten. Funktionärer som handhar en detaljbudget kan i samråd med sektionsstyrelse revidera denna under eller inför ett verksamhetsår. Sådana ändringar skall redovisas på styrelsemöte (DM).
-
-Förklaring
-----------
-
-Intäkter är vad nämnden har för totala intäkter under året. Utgifter är vad nämnden har för totala utgifter under året. Extern kostnad är de kostnader som gagnar hela sektionen, de som bedömer detta är i stigande ordning kassör, styrelse, revisorer, SM. Exempel är sittningar hela sektionen är bjuden till, inventarier till META, pubar mm. Intern kostnad är kostnader som gagnar en liten grupp inom sektionen, såsom styrelsen, DKM, andra nämnder med evenemang där alla inte är inbjudna. Exempel är mat, teambuilding, fika, fest, bungyjump, paintball, kryssning, thailandsresa mm. Det är särskilt viktigt att denna kostnad inte överstiger budgeten.
-
-Skyldighet
-----------
-
-Denna frihet som ges att få forma sin egen budget kräver fortfarande att pengar läggs på rätt saker och de med rätt att betala ut utgifter har rätt att neka utbetalningen om det bryter mot detta dokument. Beslutet kan överklagas enligt nämnda ordning i §8.1.
-
-Avtal
-=====
-
-Avtal kan enligt svensk lag endast undertecknas av firmatecknare eller innehavare av fullmakt. Den som skriver under ett avtal ansvarar för att orginal omgående kommer firmatecknare tillhanda. Firmatecknare ansvarar för att förvara sektionens alla gällande avtal ordnat och samlat.
-
-Serier
-======
-
-Varje projekt bör bokföra under en egen serie, nämndernas serier delas upp som följer:
-
-Centralt  
-serie C
-
-DKM  
-serie K
-
-Mottagningen  
-serie M
-
-Näringslivsgruppen  
-serie N
-
-Prylmångleriet  
-serie P
-
-
+##§10 Attestering##
+Alla utgifter skall attesteras. De som äger rätten att attestera/avslå en utgift är i stigande ordning nämndordförande/projektledare för bokföringspliktiga nämnder/projekt och firmatecknare. Nämndordförande/projektledare äger endast rätten att attestera utlägg som belastar budgeten de är ansvariga för. Avslag kan överklagas enligt ordningen i §A. Man får dock inte attestera några utlägg där man själv lagt ut pengar eller starkt gagnas av utläggets natur (t.ex. MUTA till en själv).
+Utöver dessa rättigheter så kan D-rektoratet i samråd med nämndordförande/projektledare besluta om extra attesträttigheter på DM.
+Ett utlägg attesteras genom underskrift på anvisad plats av kvittomallen. En faktura attesteras antingen skriftligt på fakturan eller genom att godkänna fakturabetalningen på banken.
+##§11 Avtal##
+Avtal kan enligt svensk lag endast undertecknas av firmatecknare eller innehavare av fullmakt. Den som önskar skriva på ett avtal i sektionens namn ska så snabbt som möjligt kontakta firmatecknare för att utreda möjligheten till att göra det. Avtal eller utfärdande av fullmakt beslutas om att skrivas under antingen genom DM, med stöd i styrdokument eller med standardavtal. Avtal kan i undantagsfall skrivas under retroaktivt. Den som med fullmakt skriver under ett avtal i sektionens namn ansvarar för att original omgående kommer firmatecknare tillhanda. Firmatecknare ansvarar för att förvara sektionens alla gällande avtal ordnat och samlat.
+##§A Beslutsordning##
+För att ha en organisation där vi kan ta snabba beslut men samtidigt ha en rättsäkerhet så sker bedömning av de delar som refererar till denna paragraf av följande instanser i stigande ordning: kassör, styrelse, revisorer, SM. Om man anser att ett beslut är felaktigt så kan man alltså överklaga till en högre instans.


### PR DESCRIPTION
Uppdatering av det ekonomiska styrdokumentet enligt proposition lagd till Val-SM 2016.

Ska endast mergeas om propositionen bifalles i sin helhet. Annars ska yrkanden in först.