### PR TITLE
Glögg-SM 2017: Propostion angående reglementesändring för skolråd

### DIFF
--- a/reglemente/body.md
+++ b/reglemente/body.md
@@ -1129,8 +1129,6 @@ Tjänsteförslagsnämnden har till uppgift att bereda och avge förslag beträff
 
 Skolrådet är öppet för alla studenter på Data och Media. Skolrådet väljer representanter till andra råd.
 
-Representanter i skolrådet utses av styrelsen.
-
 §6 Ordinarie SM
 ============
 


### PR DESCRIPTION
Reglementesändring om att ta bort raden om skolråd som togs upp på Glögg-SM 2017.

Protokollet ligger inte uppe än men handlingarna finns [här](https://drive.google.com/file/d/1t5YnlvU1Hbfy6BIzP6K9J6hjdG3sI-0J/view)