### PR TITLE
Motion angående D-Dagens budget

### DIFF
--- a/reglemente/body.md
+++ b/reglemente/body.md
@@ -190,7 +190,8 @@ Näringslivsgruppen har till uppgift att informera näringslivet om sektionen oc
 
 ### §3.7.2 Organisation
 
-Näringslivsgruppen leds av Näringslivsansvarig och D-Dagenansvarig. Inom Näringslivsgruppen är D-Dagenansvarig ytterst ansvarig för sektionens arbetsmarknadsdag och Näringslivsansvarig är ytterst ansvarig för all annan verksamhet. D-Dagens projektgrupps sammansättning utses av D-Dagenansvarig och övriga medlemmar utses av Näringslivsansvarig.
+Näringslivsgruppen leds av Näringslivsansvarig och D-Dagenansvarig. Inom Näringslivsgruppen är D-Dagenansvarig ytterst ansvarig för sektionens arbetsmarknadsdag och Näringslivsansvarig är ytterst ansvarig för all annan verksamhet. D-Dagens projektgrupps sammansättning utses av D-Dagenansvarig och övriga medlemmar utses av Näringslivsansvarig. Näringslivsgruppen utom D-Dagen och D-Dagen budgeteras separat. Näringslivsansvarig och D-Dagenansvarig har båda attesträtt för verksamheten i hela nämnden
+Näringslivsgruppen.
 
 ### §3.7.3 Verksamhet
 


### PR DESCRIPTION
Reglementesändringar till följd av "Motion angående D-Dagens budget".

att i reglementets §3.7.2 (Nämnder → Näringslivsgruppen → Organisation) lägga till följande: “Näringslivsgruppen utom D-Dagen och D-Dagen budgeteras separat. Näringslivsansvarig och D-Dagenansvarig har båda attesträtt för verksamheten i hela nämnden
Näringslivsgruppen.”