### PR TITLE
Revisions-SM, 6.5 Vaskandet av Crashmedaljer

### DIFF
--- a/reglemente/body.md
+++ b/reglemente/body.md
@@ -975,8 +975,6 @@ Har till uppgift att ansvara över sektionens bil och tillhörande ekonomi.
 
 Hanterar bokning, regler för bilen, reparation/underhåll, parkeringstillstånd, försäkringar och annat som hör bilen till.
 
-Kan besluta att utdela medaljer, kallade Crashmedaljer, till de personer som orsakat bilen skada. Crashmedaljer får inte utdelas vid allvarlig skada på bilen, olovlig körning, rattfylleri eller personskada.
-
 #### §4.3.8.3 Organisation
 
 I det fall att posten är vakantsatt har Konglig Öfverdrif ansvar för bilen.


### PR DESCRIPTION
Tog bort stycket om att dela ut Crashmedaljer enligt beslut från Revisions-SM 2021.