### PR TITLE
22S02-06 Beslutsuppf. prop 5 dFunkpol val-sm 2022

### DIFF
--- a/dfunkpolicy/body.md
+++ b/dfunkpolicy/body.md
@@ -26,7 +26,7 @@ Till varje Sektionsmöte förväntas du som δ-funktionär skriva en rapport om 
 §1.5 Gå på utbildning
 ----------------
 
-Varje termin anordnas det en funktionärsutbildning och en JML-utbildning. Som funktionär är det din skyldighet att gå på båda dessa en gång under din mandatperiod.
+Varje termin anordnas det en funktionärsutbildning och en JML-utbildning. Som funktionär är det din skyldighet att gå på funktionärutbildningen en gång under din mandatperiod såvida du inte redan har gått utbildningen under en tidigare mandatperiod. D-rektoratet har alltid rätt att begära att du går på funktionärsutbildningen under en specifik mandatperiod, vilket då är din skyldighet. Du har en skyldighet att gå på JML-utbildningen en gång under din mandatperiod.
 
 §1.6 D-råd
 -----------------


### PR DESCRIPTION
Ändrar så att dfunk endast behöver gå på en dfunkutbildning och inte en per mandatperiod. 
Drek kan säga att de måste gå ändå.