### PR TITLE
Editorial change - Make .md file formatting more consistent between documents

### DIFF
--- a/ekonomiskt_styrdokument/body.md
+++ b/ekonomiskt_styrdokument/body.md
@@ -1,50 +1,77 @@
-#Ekonomiskt styrdokument#
-##§1 Bakgrund##
+Ekonomiskt styrdokument
+=============
+
+§1 Bakgrund
+---------------
+
 Detta dokument ska fylla två funktioner. Dels ska det ange de för sektionen gällande regler för hur ekonomin sköts. Dokumentet ska även fungera som en snabb utbildning i hur funktionärer och nämnder ska sköta sin ekonomi och ekonomiska redovisning.
-##§2 Bokföringsplikt##
+
+§2 Bokföringsplikt
+---------------
+
 Bokföringspliktiga nämnder såsom DKM, Mottagningen och Prylmångleriet samt vissa projekt sköter sin egen bokföring. Bokföring skall skötas löpande med målsättningen att vara färdig senast nästföljande månadsskifte då det ej är sommarferie. Utöver denna målsättning kan kassören sätta krav på bokföringsdeadlines. Om en nämnd eller ett projekt inte håller utsatta deadlines äger D-rektoratet rätten att applicera restriktioner på dess verksamhet såsom att förbjuda bruk av sektionens alkoholtillstånd.
 Om en nämnd eller ett projekt bokför kontinuerligt och arbetar mot tidsmålet ovan så kan nämnden/projektet belönas. Man kan få extra pengar till bokförings-MUTA/fika/teambuilding från en för ändamålet reserverad budgetpost. Bedömning av detta och utdelning av dessa pengar sker av kassör.
 
-##§3 Skulder till engagerade##
+§3 Skulder till engagerade
+---------------
+
 Kvitton för inköp åt sektionen skall senast lämnas in 30 dagar efter då inköpet gjordes för att skulden ska betalas tillbaka, därefter kan den nekas. Skulder ska betalas tillbaka till engagerade inom 5 veckor (ej under ferie) under förutsättning att alla uppgifter är rätt registrerade och det framgår i vilket syfte inköpet är gjort.
 
-##§4 Hantering av kontanter##
+§4 Hantering av kontanter
+---------------
+
 Sektionen har en handkassa benämnd centralt, denna används av Mottagningen, DKM och sektionen i stort. Överföringar mellan handkassor bokförs av källan för överföringen.
 Summor över 1000 kronor får inte förvaras i sektionslokalen längre än över natten och då endast i låst utrymme. Undantaget från detta är pengar som förvaras i depositionsskåpet.
-##§5 Lager##
 
-###§5.1 Förvaltning av dryckeslager###
+§5 Lager
+---------------
+
+### §5.1 Förvaltning av dryckeslager
 DKM förvaltar sektionens dryckeslager, utom under mottagningsperioden då Mottagningen tar över den uppgiften. Det innebär att det i huvudsak är de som fyller på lagren och bokför påfyllning. Sprit, vin, cider och öl som serveras vid pub­- och klubbverksamhet ska lagerföras.
 Dryckeslagren ska inventeras minst en gång varannan månad samt innan och efter mottagningsperioden. Det inventerade värdet ska synkas mot bokföringen genom av kassör särskilt anvisad resultatgrupp. Schablonbeloppen nämnda i §5.2 ska anpassas med hänsyn till att minimera differenserna i lagerföringen.
-###§5.2 Dryckeslager vid festtillfällen###
+
+### §5.2 Dryckeslager vid festtillfällen
 När en nämnd eller ett projekt har fest och använder sektionens dryckeslager ska det bokföras av bokföringsansvariga för nämnden eller projektet som festen ligger under. Nämnden/projektet ska både belastas för inköp av drycken och tilldelas försäljningen av den. Kostnaden för inköpet får beräknas enligt av kassören tillhandahållna schablonbelopp. Serveringsansvarig för festtillfället är ansvarig för att betalning och dagsavslut görs efter sektionens standarder. Serveringsansvarig är även ansvarig för att eventuella handkassor hanteras enligt §4 i detta dokument. Serveringsansvarig ska i skälig tid innan festtillfället kontakta den nämnd som förvaltar dryckeslagren och informera sig om gällande bestämmelser för sektionen.
-###§5.3 Andra lager###
+
+### §5.3 Andra lager
 Andra lager (till exempel ovvelager) ska inventeras minst en gång per år. Sådan inventering skall komma kassören till handa så snart som möjligt efter att den skett.
-##§6 Kvitton##
+
+§6 Kvitton
+---------------
+
 Kvitto alternativt faktura ska erbjudas i någon form för all försäljning.
 
-##§7 Fakturor##
-###§7.1 Inköp via faktura###
+§7 Fakturor
+---------------
+
+### §7.1 Inköp via faktura
 Inköp på faktura betyder för det mesta att man nyttjar ett av sektionens kreditavtal. Detta får göras av sektionens funktionärer, både direkt (att funktionären nyttjar kreditavtalet) eller indirekt (att annan person nyttjar kreditavtalet på order av funktionär). Det är funktionärens ansvar att se till att det finns utrymme i budget för kostnaderna. Det går i regel bra att nyttja kreditavtal skrivna av andra organ inom sektionen än det man handlar för, men personen som gör inköpet ansvarar själv för att vara informerad om kreditavtalets gränser.
 Stora inköp på över 50000 kr som kan komma att påverka sektionens ekonomi i stort ska meddelas kassören så fort det blir känt. Alla fakturor i sektionens namn ska skickas till sektionens gällande fakturaadress.
-###§7.2 Försäljning via faktura###
+
+### §7.2 Försäljning via faktura
 Fakturor utställda av sektionen ska skapas genom av kassör anvisad metod. Nämnder ansvarar själva för att kontinuerligt kontrollera att utskickade fakturor betalas i tid. En kopia av fakturan ska omgående komma bokföringsansvarig tillhanda.
 
-##§8 Budget##
+§8 Budget
+---------------
+
 Budgeten är ett instrument för att försöka planera och förutspå hur verksamhetsårets ekonomi kommer se ut. Budgeten ska följas i den mån som går, men om verkligheten inte tillåter detta så kan man behöva bortse från budgeten. Om en budgetöverträdelse behöver göras måste kassör informeras innan överträdelsen har skett.
 I den rambudget som beslutas om på SM finns posterna: Intäkter, Utgifter, Extern balans och Intern balans. Utöver detta krävs det att det för varje nämnd och projekt på SM kan uppvisas en detaljbudget vars externa och interna balans överensstämmer eller har ett bättre resultat än Extern balans och Intern balans i rambudgeten. Funktionärer som handhar en detaljbudget kan i samråd med sektionsstyrelse revidera denna under eller inför ett verksamhetsår. Sådana ändringar skall redovisas på styrelsemöte (DM).
-###§8.1 Förklaring###
+
+### §8.1 Förklaring
 Intäkter är nämndens totala intäkter under året. Utgifter är nämndens totala utgifter under året. Extern balans är balansen för de event och budgetposter som gagnar hela sektionen. Exempel på detta är sittningar hela sektionen är bjuden till, inventarier till META, pubar mm. Intern balans är balansen på event och budgetposter som gagnar en liten grupp inom sektionen, såsom styrelsen, DKM, andra nämnder med evenemang där alla inte är inbjudna. Exempel på denna typ av event och budgetposter är mat vid arbete (MUTA), teambuilding, fika, fest, bungyjump, paintball, kryssning, thailandsresa mm. Det är särskilt viktigt att denna kostnad inte överstiger budgeten. Vad som är externt och internt bedöms av instanserna i §A.
-###§8.2 Skyldighet###
+
+### §8.2 Skyldighet
 Denna frihet som ges att få forma sin egen budget kräver fortfarande att pengar läggs på rätt saker och de med rätt att betala ut utgifter har rätt att neka utbetalningen om det bryter mot detta dokument. Beslutet kan överklagas enligt nämnda ordning i §A.
-###§8.3 Användande av fikabudget###
+
+### §8.3 Användande av fikabudget
 Fikabudget ska gå till inköp av ﬁka på möten eller andra aktiviteter. Det är inte nödvändigt att erbjuda ﬁka på alla aktiviteter, men i de fall då ﬁka erbjuds ska den vara tillgänglig för samtliga deltagare på aktiviteten. Minst två personer ska förväntas närvara på en aktivitet för att pengar ska få tas från ﬁka budgeten. Fika ska ej ersätta måltid.
 
-##§9 Fonder##
+§9 Fonder
+---------------
 
 Datasektionen har utöver de fonder som regleras i stadgarna två andra fonder, lokalfonden och jubileumsfonden. Hur fonderna får användas regleras nedan, övrigt nyttjande av fondernas medel får beslutas av SM.
 
-###§9.1 Lokalfonden###
+### §9.1 Lokalfonden
 
 Lokalfondens medel är avsedda för att köpa in större inventarier till lokalen och att se till att sektionen har en buffert utifall att vi plötsligt skulle behöva flytta.
 
@@ -52,24 +79,27 @@ Ianspråktagande av lokalfondens medel beslutas av D-rektoratet på DM (styrelse
 
 Lokalfonden bör vara av sådan storlek att sektionen kan bekosta en lokalflytt med fondens medel.
 
-###§9.2 Jubileumsfonden###
+### §9.2 Jubileumsfonden
 
 Jubileumsfondens syfte är undvika att ett enskilt års budget belastas onödigt hårt de år då Datasektionen firar ett jubileum. Dessa pengar får tas i anspråk till jubileumsfirande efter Styrelsebeslut. Då fondens pengar inte är ämnade att användas varje år är det lämpligt att pengarna placeras med detta i åtanke.
 
 Avsättningar till jubileumsfonden bör vara av sådan storlek så att fonden uppnår en summa på 10 prisbasbelopp när ett jubileum infaller.
 
-###§9.3 Jubileumsfonden###
+### §9.3 Jubileumsfonden
 
 50 års jubileumsfondens syfte är att möjliggöra ett större evenemang vid Datasektionens 50 års Jubileum. Denna fond är tänkt att användas tillsammans med Jubileumsfonden (se §9.2 Jubileumsfonden) och utgör därför extra resurser som tillgängliggörs för att fira Datasektionens 50 års jubileum. Dessa pengar får tas i anspråk till jubileumsfirande efter Styrelsebeslut. Då fondens pengar inte är ämnade att användas varje år är det lämpligt att pengarna placeras med detta i åtanke. Avsättningar till 50 års jubileumsfonden bör vara av sådan storlek så att fonden uppnår en summa av 5 prisbasbelopp när 50 års jubileet infaller.
 
-##§10 Subventionering av profilkläder##
+§10 Subventionering av profilkläder
+---------------
+
 Kläder som tillfaller medlemmen, t.ex. hoodies med personligt tryck eller mottagningströjorna, delas in i två grupper, uniform och profilkläder. Vad som faller in under uniform bedöms av DM och ska motiveras med externa bestämmelser från till exempel Tillståndsenheten eller THS.
 
 Profilkläder får maximalt subventioneras till 50% av inköpspriset. Summan som ska subventioneras med ska budgeteras och kategoriseras som en intern kostnad.
 
 Undantaget är ifall man fått profilkläderna sponsrade. Sponsringen dras då av från summan som inte subventioneras av sektionen. Alltså kan hela tröjan betalas genom att man får 50% eller mer av tröjan sponsrad och sektionen går in och betalar resterande belopp från budgeten.
 
-##§11 Accesser##
+§11 Accesser
+---------------
 Firmatecknare och vice kassör har tillgång till att se och hantera sektionens samtliga tillgångar och transaktioner på banken.
 Revisorer har tillgång till att se sektionens samtliga tillgångar och transaktioner på banken.
 Nämndordförande och projektledare för bokföringspliktiga nämnder och projekt ska ha tillgång till att se och hantera tillgångarna som ligger på sin egen nämnds bankkonto.
@@ -77,13 +107,19 @@ Bokföringsansvariga utsedda av nämndordförande eller projektledare har rätt 
 
 Utöver dessa bankaccesser kan D-rektoratet, genom beslut på DM, besluta om att ge andra personer tillgång till att se och/eller hantera sektionens tillgångar. Firmatecknare äger även rätten att dra in personers accesser, det ska därefter prövas på nästföljande DM.
 
-##§12 Attestering##
+§12 Attestering
+---------------
+
 Alla utgifter skall attesteras. De som äger rätten att attestera/avslå en utgift är i stigande ordning nämndordförande/projektledare för bokföringspliktiga nämnder/projekt, vice kassör och firmatecknare. Nämndordförande/projektledare äger endast rätten att attestera utlägg som belastar budgeten de är ansvariga för. Avslag kan överklagas enligt ordningen i §A. Man får dock inte attestera några utlägg där man själv lagt ut pengar eller starkt gagnas av utläggets natur (t.ex. fika till en själv).
 Utöver dessa rättigheter så kan D-rektoratet i samråd med nämndordförande/projektledare besluta om extra attesträttigheter på DM.
 Ett utlägg attesteras genom sektionens system för det syftet. En faktura attesteras antingen genom sektionens system för det syftet eller genom att godkänna fakturabetalningen på banken.
 
-##§13 Avtal##
+§13 Avtal
+---------------
+
 Avtal kan enligt svensk lag endast undertecknas av firmatecknare eller innehavare av fullmakt. Den som önskar skriva på ett avtal i sektionens namn ska så snabbt som möjligt kontakta firmatecknare för att utreda möjligheten till att göra det. Avtal eller utfärdande av fullmakt beslutas om att skrivas under antingen genom DM, med stöd i styrdokument eller med standardavtal. Avtal kan i undantagsfall skrivas under retroaktivt. Den som med fullmakt skriver under ett avtal i sektionens namn ansvarar för att original omgående kommer firmatecknare tillhanda. Firmatecknare ansvarar för att förvara sektionens alla gällande avtal ordnat och samlat.
 
-##§A Beslutsordning##
+§A Beslutsordning
+---------------
+
 För att ha en organisation där vi kan ta snabba beslut men samtidigt ha en rättsäkerhet så sker bedömning av de delar som refererar till denna paragraf av följande instanser i stigande ordning: kassör, styrelse, revisorer, SM. Om man anser att ett beslut är felaktigt så kan man alltså överklaga till en högre instans.

--- a/jamlikhetspolicy/body.md
+++ b/jamlikhetspolicy/body.md
@@ -1,69 +1,95 @@
-# Jämlikhetspolicy #
-## Bakgrund ##
+Jämlikhetspolicy
+===============
+
+Bakgrund
+---------------
+
 Detta dokument har tagits fram som ett tillägg till THS JML-policy. Detta är för att det ska bli tydligt hur vi jobbar med JML på Konglig Datasektionen. Dokumentet är skapat så att varje paragraf är kopplad till en paragraf i THS-policy och det första stycket i varje paragraf är hela policypunkten. Därefter följer underparagrafer som specificerar hur vi på Konglig Datasektionen arbetar med huvudpunkterna. För begreppsdefinitioner hänvisar vi till [THS JML-policy](http://mit-kth.se/wp-content/uploads/2017/01/THS-JML-policy_reviderad.pdf).
 
-## §1 Inkludering och Mångfald ##
+§1 Inkludering och Mångfald
+---------------
+
 THS organisation och verksamhet ska ha en öppen och inkluderande kultur samt genomsyras av mångfald.
-### §1.1 ###
+
+### §1.1
 Vi strävar efter att ha stor mångfald i sektionens nämnder och projekt och tar hänsyn till sådant vid rekryteringar.
-### §1.2 ###
+
+### §1.2
 Sektionen uppmuntrar att alla tillfällen där en medlem anser att avsteg från denna policy gjorts rapporteras till någon av sektionens kontaktpersoner (se avsnitt Kontakt).
 
-## §2 Trygghet och tillgänglighet ##
+§2 Trygghet och tillgänglighet
+---------------
+
 THS ska ha en trygg och tillgänglig fysisk och psykosocial miljö där alla kan utvecklas personligt, utbildnings- och karriärmässigt.
-### §2.1 ###
+
+### §2.1
 Alla lokaler som Konglig Datasektionen använder vid sina tillställningar ska vara tillgängliga fysiskt för alla potentiella deltagare.
-### §2.2 ###
+
+### §2.2
 Funktionärer samt styrelse ska ta hänsyn till medlemmarnas arbetsbelastning och vara lyhörda kring potentiellt överarbete, och om sådant uppkommer göra förändringar för att avlasta.
-## §3 Lika villkor ##
+
+§3 Lika villkor
+---------------
+
 Inom THS ska alla behandlas på lika villkor och ha samma möjlighet att ta del av THS verksamhet och organisation.
 
-### §3.1 ###
+### §3.1
 De tillställningar som Konglig Datasektionen anordnar ska arbeta för alla deltagare ska kunna delta under samma villkor, oavsett förutsättningar för enskild deltagare.
 
-### §3.2 ###
+### §3.2
 Förtursbiljetter till evengemang ska enbart tillämpas enligt §5 Anmälningar till arrangemang i [Informationsspridningspolicyn](https://styrdokument.datasektionen.se/informationsspridningspolicy).
 
-## §4 Diskriminering och trakasserier ##
+§4 Diskriminering och trakasserier
+---------------
+
 THS ska ha nolltolerans mot diskriminering och trakasserier.
 
-### §4.1 ###
+### §4.1
 Alla förtroendevalda får utbildning i JML och vet hur de ska agera om någon kommer till dem för att få hjälp med ett jämlikhetsärende.
 
-### §4.2 ###
+### §4.2
 Det ska finnas resurser för att jobba med JML på sektionens hemsida och alla förväntas jobba aktivt med det inom sin nämnd eller projekt.
 
-### §4.3 ###
+### §4.3
 Vi uppmuntrar att eventuella händelser anmäls till rätt instans och sektionen arbetar aktivt med att förhindra liknande händelser i fortsättningen.
 
-## §5 Normkritik och Självgranskning ##
+§5 Normkritik och Självgranskning
+---------------
+
 THS ska vara aktivt normkritisk och självgranskande.
 
-### §5.1 ###
+### §5.1
 Vid varje inval ska en självutvärdering göras av ansvarig funktionär för att se så att inga bias påverkat beslutet som specificerat i [Rekryteringspolicyn](https://styrdokument.datasektionen.se/rekryteringspolicy).
 
-### §5.2 ###
+### §5.2
 Förtroendevalda ska utföra kontinuerliga självutvärderingar under hela förloppet av sina mandatperioder.
 
-## §6 Transparens ##
+§6 Transparens
+---------------
 THS ska vara en transparent organisation som kommunicerar på ett tillgängligt sätt.
 
-### §6.1 ###
+### §6.1
 Inval ska vara transparent och presenteras som specificerat i §6 av [Rekryteringspolicyn](https://styrdokument.datasektionen.se/rekryteringspolicy).
 
-### §6.2 ###
+### §6.2
 Material ska göras tillgängligt på de språk och i den utsträckning som specificerat i [Informationsspridningpolicyn](https://styrdokument.datasektionen.se/informationsspridningspolicy).
 
 
-## Ansvar ###
+Ansvar
+---------------
+
 Det yttersta ansvaret för att policyn efterlevs har Sektionsordförande, Jämlikhetsnämndens Ordförande, Studerandeskyddsombud och styrelsen.
 
-## Andra dokument ##
+Andra dokument
+---------------
+
 * [THS JML-policy](http://mit-kth.se/wp-content/uploads/2017/01/THS-JML-policy_reviderad.pdf)
 * [THS Sångpolicy](https://cdn.thskth.se/wp-content/uploads/2016/07/THS_Policy-sang_161215.pdf)
 * [KTHs uppförandekod för studenter](https://www.kth.se/student/studentliv/studentratt/uppforandekod-for-studenter-1.796562)
 
-## Kontakt ##
+Kontakt
+---------------
+
 * Sektionsordförande [ordf@datasektionen.se](mailto:ordf@datasektionen.se)
 * Jämlikhetsnämndens ordförande [jno@datasektionen.se](mailto:jno@datasektionen.se)
 * D-rektoratet (Konglig Datasektionens styrelse) [drek@datasektionen.se](mailto:drek@datasektionen.se)

--- a/klimatpolicy/body.md
+++ b/klimatpolicy/body.md
@@ -1,15 +1,22 @@
-# Klimatpolicy
+Klimatpolicy
+=============
 
-## Bakgrund
+Bakgrund
+---------------
+
 THS kårfullmäktige har tagit fram ett policydokument för att förenkla klimat- och miljöarbetet inom THS. För att ytterligare hjälpa Datasektionens funktionärer att i sitt vardagliga arbete jobba utifrån den policyn så har det här dokumentet tagits fram. För att se orginaldokumentet, se [THS Policy för Klimat och Miljö](https://cdn.thskth.se/wp-content/uploads/2020/12/ths-policy-fr-klimat-och-milj_1920-kf-06.pdf).
 
-## §1 Minska nykonsumtion
+§1 Minska nykonsumtion
+---------------
+
 Inom och mellan THS olika verksamheter ska det finnas möjlighet att dela på materiella tillgångar och därmed minska nykonsumtion.
 
 ### §1.1
 Samarbeta och dela material mellan nämnder och projekt. Om något behövs, kontakta andra nämnder och se över om dom redan äger det ni behöver.
 
-## §2 Undvik engångsartiklar
+§2 Undvik engångsartiklar
+---------------
+
 Användning av engångsartiklar och utdelningsmaterial ska undvikas i största möjliga mån. 
 
 ### §2.1
@@ -18,19 +25,25 @@ Om man ej kan undvika engångsartiklar, använd då så miljövänliga material 
 ### §2.2
 Istället för fysiskt utdelningsmaterial, se över möjligheterna till digitala alternativ, t.ex. digitala broschyrer, programblad osv.
 
-## §3 Återvinning
+§3 Återvinning
+---------------
+
 Sortering av avfall för att möjliggöra återvinning ska utföras i största möjliga mån.
 
 ### §3.1
 Se till att det finns möjlighet till sortering av avfall under event, såsom pant, glas osv.
 
-## §4 Mat
+§4 Mat
+---------------
+
 Mat med lågt klimatavtryck ska premieras i alla delar av THS verksamhet. Om kött erbjuds, ska det alltid vara som ett aktivt val.
 
 ### §4.1
 Måltider som serveras på event anordnade av sektionen ska i första hand planeras som köttfria. Det är tillåtet att erbjuda kött till de som önskar.
 
-## §5 Transport
+§5 Transport
+---------------
+
 Miljövänliga färdalternativ bör väljas om det inte orsakar signifikanta ekonomiska eller administrativa problem.
 
 ### §5.1
@@ -39,15 +52,18 @@ Använd kollektivtrafik i så stor mån som möjligt, t.ex. vid besök till Osqv
 ### §5.2
 Om ni behöver hyra bil, välj en miljövänlig då det är rimligt.
 
-## Samarbeten
+Samarbeten
+---------------
 
 Vid samarbeten med externa parter bör man uppmuntra till att den delade verksamheten har ett minimalt klimatavtryck.
 
-## Kommunikation
+Kommunikation
+---------------
 
 I redovisning av verksamheten som gått (testamente eller verksamhetsrapport) bör man, om applicerbart, berätta hur man arbetat med att minska sin verksamhets klimatavtryck.
 
-## Ansvar
+Ansvar
+---------------
 
 Styrelsen ansvarar att se till att organisation i sin helhet följer policyn, där D-SSF har det uttalade huvudansvaret.
 

--- a/rekryteringspolicy/body.md
+++ b/rekryteringspolicy/body.md
@@ -1,9 +1,13 @@
-#Rekryteringspolicy
+Rekryteringspolicy
+====================
 
-##§1 Syfte och mål##
+§1 Syfte och mål
+---------------
+
 Syftet med detta dokument är att beskriva hur inval och rekrytering till såväl nämnder som projekt vid Datasektionen ska ske. En målsättning för Datasektionen är att alla medlemmar har lika möjligheter att engagera sig inom alla delar av organisationen. Alla medlemmar ska alltid ha möjligheten att kandidera till förtroendeposter som väljs av sektionsmötet, samt till de poster som i sin tur kan utses av förtroendevalda. Detta dokument syftar till att påvisa hur ansvariga i alla sammanhang som rör inval och rekrytering ska sträva efter att ha öppna och transparenta processer, samt hur detta kan uppnås.
 
-##§2 Begrepp: Inval och rekrytering##
+§2 Begrepp: Inval och rekrytering
+---------------
 
 Ett **öppet val** till Datasektionens funktionärsposter hålls under sektionsmötet där alla medlemmar har rätt att kandidera. Undantaget är när en funktionärspost är vakantsatt, då har styrelsen möjligheten att tillförordna en medlem på posten tills dessa att fyllnadsval kan ske.
 
@@ -11,14 +15,17 @@ Med **inval** menas att en medlem av Datasektionen väljs in till en nämnd elle
 
 **Rekrytering** syftar på hur nämnder och projekt arbetar för att engagera och rekrytera fler medlemmar till sina verksamheter.
 
-##§3 Inval##
+§3 Inval
+---------------
+
 Inval som sker till nämnd eller projekt ska tydligt marknadsföras till sektionens medlemmar i sektionens officiella informationskanaler. En medlem ska därefter kunna förvänta sig att beslut som tas vid inval är välgrundade och fattade efter att ha tagit samtliga kandidater i beaktning.
 
 Den som är ansvarig för nämnden eller projektet ska inom rimliga gränser säkerställa att alla som söker ges samma förutsättningar i processen. Detta kan göras genom att samla in informationen som ligger till grund för invalsbeslutet på ett likvärdigt sätt för samtliga kandidater. Till exempel kan frågeformulär eller intervjuer som tar i beaktande såväl kandidaters personliga egenskaper som tidigare erfarenheter användas.
 
 Ansvarig funktionär ska, tillsammans med eventuell rekryterande grupp, efter varje inval göra en självutvärdering för att säkerställa att inga bias har påverkat beslutet.
 
-##§4 Rekrytering##
+§4 Rekrytering
+---------------
 
 Hur sektionsmedlemmar kan deltaga i nämnd eller projekt bör vara öppet och tydligt annonserat i sektionens officiella informationskanaler när rekrytering pågår. För de nämnder och projekt som inte utgörs av en fast grupp medlemmar bör istället aktiviteter som tar plats annonseras.
 
@@ -33,8 +40,12 @@ Hur sektionsmedlemmar kan deltaga i nämnd eller projekt bör vara öppet och ty
     - Ansvarig rekryterande funktionär ska alltid kunna motivera sina invalsbeslut.
     - Denna information ska beläggas med sekretess och enbart sittande valberedning samt revisorer får ta del av den.
 
-##§5 Intern rekrytering##
+§5 Intern rekrytering
+---------------
+
 Inom nämnder och projekt kan det finnas interna ansvarsområden som fördelas mellan de engagerade medlemmarna. Exempel på interna ansvarsområden kan vara städskri i METAdorerna och barmästare i DKM. Möjligheten för en medlem att ansvara för ett internt ansvarsområde ska i dessa fall kommuniceras öppet inom nämnden eller projektet.
 
-##§6 Transparens##
+§6 Transparens
+---------------
+
 För att bidra till ökad transparens vid inval och rekrytering ska nämndordförande och projektledare varje SM presentera det underlag som legat till grund för inval och rekryteringar som gjorts sedan föregående SM ifall inval eller rekrytering till nämnden eller projektet skett. Underlaget ska styrka att gjorda rekryteringar och inval gjorts på ett jämlikt och meritbaserat sätt. Detta innebär inte att rekryteringar eller inval ska rättfärdigas på individnivå utan kan i praktiken betyda att man till exempel presenterar vilken erfarenhet och/eller vilka personliga egenskaper man generellt premierat hos kandidater.


### PR DESCRIPTION
A few of the policy documents had differing formatting from the others. In 2 cases this made them quite annoying to read in github, since github did not display them with markdown formatting.

The used style of formatting was chosen since the majority of the policies were in that format, and in particular the stadgar and reglemente were using that format.

Does not affect how the documents are displayed on [styrdokument.datasektionen.se](https://styrdokument.datasektionen.se), hence it should be an editorial change. 