### PR TITLE
Redaktionell ändring - fixa lista i D-Dagens reglemente

### DIFF
--- a/reglemente/body.md
+++ b/reglemente/body.md
@@ -582,10 +582,15 @@ D-Dagen leds av D-Dagenansvariga. D-Dagens medlemmar utses av D-Dagenansvariga
 
 ### §3.22.3 Verksamhet
 D-Dagen skall
+
 - göra reklam för arbetsmarknadsdagen gentemot berörda studenter
+
 - hålla och ständigt förbättra kontakten med näringslivet och dess deltagande på arbetsmarknadsdagen
+
 - arrangera en arbetsmarknadsmässa och tillhörande sittning som främjar mötet mellan berörda studenter och näringslivet
+
 - sköta D-Dagens faktureringar
+
 - se till att sektionen uppfyller avtal framförhandlade av D-Dagen.
 
 ### §3.22.4 Avtal


### PR DESCRIPTION
Attempt to fix list in D-dagens reglemente.

Not tested locally since the `bawang-styrdokument -> taitan -> styrdokument` chain is a bit annoying to setup locally, but it is the same format as other lists now, so it should work.

