### PR TITLE
Update links in policy documents

### DIFF
--- a/jamlikhetspolicy/body.md
+++ b/jamlikhetspolicy/body.md
@@ -4,7 +4,7 @@ Jämlikhetspolicy
 Bakgrund
 ---------------
 
-Detta dokument har tagits fram som ett tillägg till THS JML-policy. Detta är för att det ska bli tydligt hur vi jobbar med JML på Konglig Datasektionen. Dokumentet är skapat så att varje paragraf är kopplad till en paragraf i THS-policy och det första stycket i varje paragraf är hela policypunkten. Därefter följer underparagrafer som specificerar hur vi på Konglig Datasektionen arbetar med huvudpunkterna. För begreppsdefinitioner hänvisar vi till [THS JML-policy](http://mit-kth.se/wp-content/uploads/2017/01/THS-JML-policy_reviderad.pdf).
+Detta dokument har tagits fram som ett tillägg till THS JML-policy. Detta är för att det ska bli tydligt hur vi jobbar med JML på Konglig Datasektionen. Dokumentet är skapat så att varje paragraf är kopplad till en paragraf i THS-policy och det första stycket i varje paragraf är hela policypunkten. Därefter följer underparagrafer som specificerar hur vi på Konglig Datasektionen arbetar med huvudpunkterna. För begreppsdefinitioner hänvisar vi till [THS JML-policy](https://drive.google.com/drive/folders/1Yg90ggSuvpP_9858ByotplhSgR01l6aX?usp=sharing).
 
 §1 Inkludering och Mångfald
 ---------------
@@ -83,9 +83,9 @@ Det yttersta ansvaret för att policyn efterlevs har Sektionsordförande, Jämli
 Andra dokument
 ---------------
 
-* [THS JML-policy](http://mit-kth.se/wp-content/uploads/2017/01/THS-JML-policy_reviderad.pdf)
-* [THS Sångpolicy](https://cdn.thskth.se/wp-content/uploads/2016/07/THS_Policy-sang_161215.pdf)
-* [KTHs uppförandekod för studenter](https://www.kth.se/student/studentliv/studentratt/uppforandekod-for-studenter-1.796562)
+* [THS JML-policy](https://drive.google.com/drive/folders/1Yg90ggSuvpP_9858ByotplhSgR01l6aX?usp=sharing)
+* [THS Sångpolicy](https://drive.google.com/drive/folders/15GQMVeBq5oZzjLipTbLVJlSUqhQ4Nf_g?usp=sharing)
+* [KTHs uppförandekod för studenter](https://www.kth.se/student/studier/rattigheter-och-skyldigheter/uppforandekod-1.796562)
 
 Kontakt
 ---------------

--- a/klimatpolicy/body.md
+++ b/klimatpolicy/body.md
@@ -4,7 +4,7 @@ Klimatpolicy
 Bakgrund
 ---------------
 
-THS kårfullmäktige har tagit fram ett policydokument för att förenkla klimat- och miljöarbetet inom THS. För att ytterligare hjälpa Datasektionens funktionärer att i sitt vardagliga arbete jobba utifrån den policyn så har det här dokumentet tagits fram. För att se orginaldokumentet, se [THS Policy för Klimat och Miljö](https://cdn.thskth.se/wp-content/uploads/2020/12/ths-policy-fr-klimat-och-milj_1920-kf-06.pdf).
+THS kårfullmäktige har tagit fram ett policydokument för att förenkla klimat- och miljöarbetet inom THS. För att ytterligare hjälpa Datasektionens funktionärer att i sitt vardagliga arbete jobba utifrån den policyn så har det här dokumentet tagits fram. För att se orginaldokumentet, se [THS Policy för Klimat och Miljö](https://drive.google.com/drive/folders/11rBxjveYLkQ-NyzJIg0KEuDqdQrqpYNJ).
 
 §1 Minska nykonsumtion
 ---------------


### PR DESCRIPTION
The links in jämlikhetspolicyn and miljöpolicyn were either not working or linking to old documents.

I think it is best to link to the drive folders rather than the PDF documents since they will (hopefully) also contain all updated policies in the future as well. 

should be a redaktionell ändring