### PR TITLE
17S03-01 Stageändring budget-sm 2017 

### DIFF
--- a/stadgar/body.md
+++ b/stadgar/body.md
@@ -199,7 +199,7 @@ tillsändas THS styrelse.
 
 ## §3.8 Interpellation, motion och proposition
 
-Motion eller interpellation till SM ska vara D-rektoratet tillhanda senast 14 dagar före SM. D-rektoratet ska skriftligen besvara samtliga motioner.
+Motion eller interpellation till SM ska vara D-rektoratet tillhanda senast 14 dagar före SM. D-rektoratet ska skriftligen besvara samtliga motioner, såvida inte motionen dras tillbaka av motionären innan SM.
 
 Förslag från D-rektoratet benämns proposition.
 


### PR DESCRIPTION
Missad beslutsuppföljning från budget-sm 2017. Om att D-rek ej behöver besvara motioner som dras tillbaka innan SM. Proposition angående Städ i formalian.

Denna del av beslutet har inte påverkats av något av besluten tagna på SM 2018-2022.