### PR TITLE
17S04-02 Stadgeändring Glögg-SM 2017

### DIFF
--- a/stadgar/body.md
+++ b/stadgar/body.md
@@ -200,6 +200,7 @@ tillsändas THS styrelse.
 ## §3.8 Interpellation, motion och proposition
 
 Motion eller interpellation till SM ska vara D-rektoratet tillhanda senast 14 dagar före SM. D-rektoratet ska skriftligen besvara samtliga motioner.
+Motion kan även behandla begäran av misstroendeförklaring mot förtroendevald.
 
 Förslag från D-rektoratet benämns proposition.
 


### PR DESCRIPTION
Beslutsuppföljning som hade missats från Glögg-SM 2017 om att motion kan begära misstroendeförklaring mot förtroendevald. Obs att denna mening behöver vara efter stadgeändringen i 17S03-01. 

Det här beslutet har inte påverkats av beslut tagna på SM mellan 2018-2022.