### PR TITLE
18S02-02 Korrigering av beslutuppf. Val-SM 2018

### DIFF
--- a/stadgar/body.md
+++ b/stadgar/body.md
@@ -413,7 +413,7 @@ D-rektoratet ansvarar för att projektledare i aktiva projekt får ta del av sam
 
 ## §7.5 Delade projekt
 
-Ett delat projekt är ett projekt som delas mellan sektionen och en eller flera andra sektioner. Ett delat projekt startas på samma sätt som ett vanligt projekt med tillägget att efter att projektledare valts ska ett avtal upprättas mellan sektionen och de sektioner som projektet delas med som beskriver hur projektet ska drivas, hur dess ekonomi ska skötas samt hur resultatet ska delas upp. Detta avtal beslutas om av D-rektoratet. Den del av projektets budget som tillhör sektionen förfogas över enligt sektionens ekonomiska styrdokument.
+Ett delat projekt är ett projekt som delas mellan sektionen och en eller flera andra sektioner. Ett delat projekt startas på samma sätt som ett vanligt projekt med tillägget att efter att projektledare valts ska ett avtal upprättas mellan sektionen och de sektioner som projektet delas med som beskriver hur projektet ska drivas, hur dess ekonomi ska skötas samt hur resultatet ska delas upp. Detta avtal beslutas om av D-rektoratet.
 
 # §8 Revision
 


### PR DESCRIPTION
På Val-SM 2018 så beslutades det att inte ha med den sista meningen i stycket. Dvs. "Den del av projektets budget som tillhör sektionen förfogas över enligt sektionens ekonomiska styrdokument.". Men när beslutsuppföljningen gjordes för punkten så verkar det som att meningen råkade hamna med. I motionen "Motion angående Delade Projekt i stadgarna"

Denna del av stadgarna har inte ändrats i något av de övriga SM:erna 2018-2022.