### PR TITLE
23S04-1 Tar bort missad verksamhet i reglementet

### DIFF
--- a/reglemente/body.md
+++ b/reglemente/body.md
@@ -79,10 +79,6 @@ Idrottsnämnden leds av Sektionsidrottsledaren.
 
 Övriga medlemmar är samtliga intresserade sektionsmedlemmar.
 
-### §3.2.3 Verksamhet
-
-Idrottsnämnden ska annordna olika typer av idrottsaktiviteter för sektionens medlemmar.
-
 ## §3.3 Informationsorganet
 
 ### §3.3.1 Ändamål


### PR DESCRIPTION
Tar bort Idrottsnämndens verksamhet från reglementet. Då detta missades i PR som verkställde resterande del av proppen.