### PR TITLE
Put newlines before headings

### DIFF
--- a/pm/pm_verksamhet/body.md
+++ b/pm/pm_verksamhet/body.md
@@ -1,6 +1,7 @@
 <!-- Konglig Datasektionens PM för Nämnd- och Funktionärsverksamhet -->
 
 # §1 Nämnder
+
 ## § 1.1 Sektionslokalsgruppen
 
 Sektionslokalsgruppen ska:
@@ -11,6 +12,7 @@ Sektionslokalsgruppen ska:
 * Organisera städning av sektionslokalen, bland annat genom måndagsstäd
 * Upprätta och underhålla ett dokument med regler för sektionslokalen
 * Sköta utveckling av sektionslokalen
+
 ## §1.2 Idrottsnämnden
 
 Idrottsnämnden ska:
@@ -24,6 +26,7 @@ Informationsorganet ska:
 * Underhålla och utveckla sektionens datasystem
 * Ansvara för drift och underhåll av sektionens servrar
 * Engagera sektionsmedlemmar i underhåll av sektionens system och i konstruktionen av nya
+
 ## §1.4 Jämlikhetsnämnden
 
 Jämlikhetsnämnden ska:
@@ -37,6 +40,7 @@ Jämlikhetsnämnden ska:
 * Ha löpande samarbete med KTH, EECS och THS om JML-arbeten
 * Synliggöra sitt arbete för resten av sektionen
 * Anordna minst en JML-utbildning per termin för sektionens funktionärer.
+
 ## §1.5  Klubbmästeriet
 
 Datas Klubbmästeri (DKM) ska:
@@ -45,6 +49,7 @@ Datas Klubbmästeri (DKM) ska:
 * Vid behov assistera vid andra sektionsrelaterade arrangemang
 * Anordna den traditionella dJulmiddagen
 * Sköta den kontinuerliga inventeringen och lagerhållningen av dryckeslagret
+
 ## §1.6  Mottagningen
 
 Mottagningen ska:
@@ -56,6 +61,7 @@ Mottagningen ska:
 * Introducera internationella studenter med anknytning till datateknikprogrammet till sektionen
 * Introducera de nyantagna studenterna till sektionens JML-arbete
 * Involvera resten av sektionens nämnder, projekt och funktionärer i ett flertal event
+
 ## §1.7  Näringslivsgruppen
 
 Näringslivsgruppen ska:
@@ -66,6 +72,7 @@ Näringslivsgruppen ska:
 * Tillsammans med D-rektoratet samordna prissättning för alla näringslivssamarbeten utanför D-Dagens verksamhet
 * Hålla och ständigt förbättra kontakten med näringslivet
 * Se till att sektionen uppfyller avtal framförhandlade av Näringslivsgruppen.
+
 ## §1.8  Qulturnämnden
 
 Qulturnämnden ska:
@@ -74,6 +81,7 @@ Qulturnämnden ska:
 * Ansvara för inköp och underhåll av qultur i sektionslokalen och digitalt
 * Årligen utse och Q-märka en person, ett ting, en företeelse eller något annat som man anser är ett gott exempel på god qultur. Q-märkningen ska lämpligen förevigas i form av ett tygmärke.
 * Samarbeta med DESC respektive TM för överlappande verksamhet
+
 ## §1.9  Ada
 
 Ada ska:
@@ -81,6 +89,7 @@ Ada ska:
 * Verka för att  ge tjejer och icke-binära på Datasektionen en möjlighet att nätverka med varandra
 * Anordna flertalet event av olika slag där möjlighet till nätverkande finns. Minst två gånger per läsår ska event anordnas som endast är ämnade för tjejer och icke-binära. Exempel på sådana är sittningar, middagar eller myskvällar
 * Arbeta för att synliggöra behovet av nämnden och liknande satsningar inom sektionen, inom THS och på ingenjörsutbildningar över lag
+
 ## §1.10  Data Et Medias OrquesterNämnd
 
 Data Et Medias OrquesterNämnd (DEMON) ska:
@@ -94,6 +103,7 @@ Data Et Medias OrquesterNämnd (DEMON) ska:
 * Anordna regelbundna repetitioner för DEMON:s medlemmar
 * Bistå annan sektionsverksamhet genom spelningar på evenemang
 * Samordna gemensamma besök på konserter/festivaler/spelningar
+
 ## §1.11  Datasektionens E-Sports Community
 
 Datasektionens E-Sports Community ska:
@@ -102,6 +112,7 @@ Datasektionens E-Sports Community ska:
 * Samarbeta med utomstående företag och/eller organisationer i syfte att sektionens medlemmar ska få utöva e-sport på en högre nivå
 * Skapa en tillhörighet i sektionens e-sportsutövande så att även nybörjare vill engagera sig.
 * Samarbeta med Qulturnämnden för överlappande verksamhet
+
 ## §1.12  Prylmångleriet
 
 Prylmångleriet ska:
@@ -113,6 +124,7 @@ Prylmångleriet ska:
 * Hjälpa Ettan att utforma och beställa årskursmärken
 * Vid jubileum och andra större händelser på sektionen, i samarbete med ansvariga för händelsen, utforma och beställa prylar relaterade till händelsen
 * Hjälpa andra nämnder och projekt med försäljning av märken eller motsvarande föremål, samt ansvara för inköp och administration av sådana märken eller föremål. Prylmångleriet och nämnden eller projektet kan komma överens om egna lösningar för vem som sköter administration och inköp. Nämnden eller projektet bestämmer vem som får köpa märket eller föremålet
+
 ## §1.13  Baknämnden
 
 Baknämnden ska:
@@ -122,6 +134,7 @@ Baknämnden ska:
 * Dokumentera recept så att kommande årgångar ska kunna ta del av dem
 * Anordna event där bakningsintresserade sektionsmedlemmar får delta
 * Sköta inventering av ingredienser och redskap
+
 ## §1.14  Internationella nämnden
 
 Internationella nämnden ska:
@@ -134,6 +147,7 @@ Internationella nämnden ska:
 * Genomföra minst två event per termin speciellt för internationella studenter, varav ett ska vara ett välkomstevent direkt efter THS internationella mottagning
 * Främja informationsspridning på engelska inom sektionen
 * Verka för ökad integration mellan nationella och internationella studenter på EECS-skolan.
+
 ## §1.15  Tag Monkeys
 
 Tag Monkeys ska:
@@ -144,6 +158,7 @@ Tag Monkeys ska:
 * Administrera sektionens konstnärliga licenser och kunna låna ut dessa till övriga sektionen vid behov
 * Samarbeta med övriga sektionen där det finns behov eller önskemål av design och konst
 * Samarbeta med Qulturnämnden för överlappande verksamhet
+
 ## §1.16  Redaqtionen
 
 Redaqtionen ska:
@@ -151,6 +166,7 @@ Redaqtionen ska:
 * Ge ut sektionstidningen dbuggen fysiskt och/eller digitalt
 * Ge ut en nØlledbuggen till nØllan under Mottagningen
 * Dela med sig av dbuggen till andra D-sektioner i Sverige
+
 ## §1.17  Datasladden
 
 Datasladden ska: 
@@ -159,12 +175,14 @@ Datasladden ska:
 * Sköta reparation, underhåll och utveckling av sektionsbilen
 * Utforma samt upprätthålla regler för sektionsbilen
 * Se till att körjournalen används av alla som brukar sektionsbilen
+
 ## §1.18  Scala
 
 Scala ska:
 
 * Regelbundet anordna körrep där nämndmedlemmar får sjunga tillsammans
 * Bistå annan sektionsverksamhet genom uppträdanden på Vårbalen eller liknande evenemang
+
 ## §1.19  D-Dagen
 
 D-Dagen ska:
@@ -173,6 +191,7 @@ D-Dagen ska:
 * Hålla och ständigt förbättra kontakten med näringslivet och dess deltagande på arbetsmarknadsdagen
 * Arrangera en arbetsmarknadsmässa och tillhörande sittning som främjar mötet mellan berörda studenter och näringslivet
 * Se till att sektionen uppfyller avtal framförhandlade av D-Dagen.
+
 ## §1.20  dJulkalendern
 
 dJulkalendern ska:
@@ -180,6 +199,7 @@ dJulkalendern ska:
 * Anordna en CTF-liknande tävling, dJulkalendern, på den världsvida webben för Konglig Datasektionens medlemmar samt övriga intresserade. Tävlingen ska ske i samband med julen
 * Anordna en CTF-liknande tävling, dHöstkalendern, för nyantagna medlemmar under Mottagningen
 # §2 Funktionärer
+
 ## §2.1  Fanbärare
 
 Fanbärare ska:
@@ -187,6 +207,7 @@ Fanbärare ska:
 * Närvara på så många som möjligt av de tillställningar till vilka de inbjuds av THS eller SSCO, samt i andra sammanhang efter beslut av D-rektoratet
 * Hålla sektionens fana i gott skick
 * Bära hönan fagt
+
 ## §2.2  Sektionshistoriker
 
 Sektionshistorikern ska:
@@ -197,6 +218,7 @@ Sektionshistorikern ska:
 * Varje år upprätta en årskrönika
 
 Sektionshistorikern har som kunskapskälla tillgång till GUDAR-gruppen, Gamla Uvar på Data med Anrika Redogörelser.
+
 ## §2.3  D-Fest
 
 D-Fest ska:
@@ -204,6 +226,7 @@ D-Fest ska:
 * Anordna två skiftesgasquer per år, en efter Glögg-SM och en efter Val-SM. Syftet med skiftesgasquerna är att hedra sektionens avträdande och tillträdande funktionärer.
 * Anordna regelbundna teambuildings för sektionens funktionärer.
 * Eventuellt anordna andra sittningar och evenemang tillsammans med andra sektioner och studentkårer för att representera sektionen utåt.
+
 ## §2.4  Sångledare
 
 Sångledare ska:


### PR DESCRIPTION
In the rendered HTML, they were part of the preceding list, which made them indented. Not sure if it's a skill issue of the markdown parser we're using or however wrote this PM in markdown, but does not matter from now on.