### PR TITLE
Korrigera Kommunikationsgruppens titelstorlek

### DIFF
--- a/reglemente/body_sv.md
+++ b/reglemente/body_sv.md
@@ -618,14 +618,14 @@ Talmanspresidiet ser till att nödvändiga arrangemang är genomförda inför et
 
 Talmanspresidiet är neutralt och uttalar inte sina personliga ståndpunkter i sakfrågor.
 
-# §4.28 Kommunikationsgruppen
+## §4.28 Kommunikationsgruppen
 
-## §4.28.1 Ändamål
+### §4.28.1 Ändamål
 
 Kommunikationsgruppen ska ansvara för sektionens kommunikation utåt och inåt.
 Kommunikationsgruppen ansvarar för sektionens övergripande kommunikationsstrategi och bistår andra nämnder, funktionärer och projekt med deras kommunikation.
 
-## §4.28.2 Organisation
+### §4.28.2 Organisation
 
 Kommunikationsgruppen leds av Kommunikatör. Internfunktionärer utses av Kommunikatör.
 


### PR DESCRIPTION
Jag vet att Kommunikationsgruppen är cool men vi behöver nog inte så stora titlar för att visa det.