### PR TITLE
Konsekvensnumrera pekare

### DIFF
--- a/pm/pm_dfunk/body_sv.md
+++ b/pm/pm_dfunk/body_sv.md
@@ -60,4 +60,6 @@ Flera gånger per år ska D-fest å D-rektoratet vägnar bjuda alla δ-funktion�
 
 ## §2.3 Medaljer
 
-Om D-rektoratet anser att en δ-funktionär gjort ett bra jobb och och gjort sitt bästa för att uppfylla kraven i §1 så belönas de av D-rektoratet med en δ-funktionärsmedalj.”
+Om D-rektoratet anser att en δ-funktionär gjort ett bra jobb och och gjort sitt bästa för att uppfylla kraven i §[1] så belönas de av D-rektoratet med en δ-funktionärsmedalj.”
+
+[1]: #1-skyldigheter

--- a/pm/pm_ekonomi/body_sv.md
+++ b/pm/pm_ekonomi/body_sv.md
@@ -42,7 +42,7 @@ Kvitton som inte attesterats eller saknar nödvändig information och inte utbet
 
 DKM och MKM förvaltar var sitt dryckeslager, utom under mottagningsperioden då Mottagningen tar över DKM:s dryckeslager från DKM. Det innebär att det i huvudsak är de som fyller på lagren och bokför påfyllning. Sprit, vin, cider och öl som serveras vid pub-, klubb- och sittningsverksamhet ska lagerföras
 
-Dryckeslagren ska inventeras minst en gång per period samt innan och efter mottagningsperioden. Bokföringens lagervärden ska korrigeras efter genomförd inventering. Schablonbeloppen nämnda i §4.2 ska anpassas med hänsyn till att minimera differenserna i lagerföringen.
+Dryckeslagren ska inventeras minst en gång per period samt innan och efter mottagningsperioden. Bokföringens lagervärden ska korrigeras efter genomförd inventering. Schablonbeloppen nämnda i §[4.2] ska anpassas med hänsyn till att minimera differenserna i lagerföringen.
 
 ## §4.2 Dryckeslager vid festtillfällen
 
@@ -78,7 +78,7 @@ Budgeten är ett instrument för att försöka planera och förutspå hur verksa
 
 ## §7.1 Skyldighet
 
-Denna frihet som ges att få forma sin egen budget kräver fortfarande att pengar läggs på rätt saker och de med rätt att betala ut utgifter har rätt att neka utbetalningen om det bryter mot detta dokument. Ett sådant nekande bör kunna motiveras med hänsyn till relevanta regler, och man har rätt till en sådan motivering om den efterfrågas. Beslutet kan överklagas enligt nämnda ordning i §A.
+Denna frihet som ges att få forma sin egen budget kräver fortfarande att pengar läggs på rätt saker och de med rätt att betala ut utgifter har rätt att neka utbetalningen om det bryter mot detta dokument. Ett sådant nekande bör kunna motiveras med hänsyn till relevanta regler, och man har rätt till en sådan motivering om den efterfrågas. Beslutet kan överklagas enligt nämnda ordning i §[A].
 
 ## §7.2 Fördelning och användning av teambuilding-, personalvård- och fikabudget
 
@@ -161,7 +161,7 @@ Avsättningar till Jubileumsfonden bör vara av sådan storlek så att fonden up
 
 ## §8.3 50-år jubileumsfonden
 
-50-år jubileumsfondens syfte är att möjliggöra ett större evenemang vid Datasektionens 50-års jubileum. Denna fond är tänkt att användas tillsammans med Jubileumsfonden (se §8.2 Jubileumsfonden) och utgör därför extra resurser som tillgängliggörs för att fira Datasektionens 50-års jubileum. Dessa pengar får tas i anspråk till jubileumsfirande efter Styrelsebeslut. Då fondens pengar inte är ämnade att användas varje år är det lämpligt att pengarna placeras med detta i åtanke. Avsättningar till 50-år jubileumsfonden bör vara av sådan storlek så att fonden uppnår en summa av 5 prisbasbelopp när ett 50-års jubileum infaller.
+50-år jubileumsfondens syfte är att möjliggöra ett större evenemang vid Datasektionens 50-års jubileum. Denna fond är tänkt att användas tillsammans med Jubileumsfonden (se §[8.2] Jubileumsfonden) och utgör därför extra resurser som tillgängliggörs för att fira Datasektionens 50-års jubileum. Dessa pengar får tas i anspråk till jubileumsfirande efter Styrelsebeslut. Då fondens pengar inte är ämnade att användas varje år är det lämpligt att pengarna placeras med detta i åtanke. Avsättningar till 50-år jubileumsfonden bör vara av sådan storlek så att fonden uppnår en summa av 5 prisbasbelopp när ett 50-års jubileum infaller.
 
 ## §8.4 Källarfonden
 
@@ -188,7 +188,7 @@ Utöver dessa bankaccesser kan D-rektoratet, genom beslut på DM, besluta om att
 
 # §11 Attest
 
-Alla utgifter ska attesteras. De som äger rätten att attestera/avslå en utgift för nämnder eller projekt är i stigande ordning nämndordförande/projektledare för bokföringspliktiga nämnder/projekt, Vice kassör och firmatecknare. De som äger rätten att attestera/avslå en utgift för organ är i stigande ordning organledare, Vice kassör och firmatecknare. Nämndordförande/projektledare äger endast rätten att attestera utlägg som belastar budgeten de är ansvariga för. Beslut kan överklagas enligt ordningen i §A. Man får dock inte attestera några utlägg där man själv lagt ut pengar eller starkt gagnas av utläggets natur (t.ex. fika till en själv).
+Alla utgifter ska attesteras. De som äger rätten att attestera/avslå en utgift för nämnder eller projekt är i stigande ordning nämndordförande/projektledare för bokföringspliktiga nämnder/projekt, Vice kassör och firmatecknare. De som äger rätten att attestera/avslå en utgift för organ är i stigande ordning organledare, Vice kassör och firmatecknare. Nämndordförande/projektledare äger endast rätten att attestera utlägg som belastar budgeten de är ansvariga för. Beslut kan överklagas enligt ordningen i §[A]. Man får dock inte attestera några utlägg där man själv lagt ut pengar eller starkt gagnas av utläggets natur (t.ex. fika till en själv).
 
 Utöver dessa rättigheter så kan D-rektoratet i samråd med nämndordförande/projektledare besluta om extra attesträttigheter på DM.
 
@@ -217,3 +217,7 @@ För att risken inte ska bli för hög ska investeringar enbart ske i börsnoter
 # §A Beslutsordning
 
 För att ha en organisation där vi kan ta snabba beslut men samtidigt ha en rättsäkerhet sker bedömning av de delar som refererar till denna paragraf av följande instanser i stigande ordning: Kassör, styrelse, Revisorer, SM. Om man anser att ett beslut är felaktigt kan man alltså överklaga till en högre instans.
+
+[4.2]: #4-2-dryckeslager-vid-festtillfällen
+[8.2]: #8-2-jubileumsfonden
+[A]: #a-beslutsordning

--- a/policies/uppforandepolicy/body_sv.md
+++ b/policies/uppforandepolicy/body_sv.md
@@ -63,9 +63,9 @@ Trygghetsrådet ska:
 
 - arbeta för att förbättra situationen för de inblandade, även då en faktisk konsekvens enligt konsekvenstrappan ej blir aktuell
 
-- sträva efter att agera objektivt. Som medlem i Trygghetsrådet ska man avlägsna sig vid hanteringen av specifika fall då detta inte anses möjligt. Vid situation där en medlem i Trygghetsrådets oberoende - ifrågasätts skall denne entledigas från ärendet och ersättas enligt $[4.7] Vakanta poster i Trygghetsrådet
+- sträva efter att agera objektivt. Som medlem i Trygghetsrådet ska man avlägsna sig vid hanteringen av specifika fall då detta inte anses möjligt. Vid situation där en medlem i Trygghetsrådets oberoende - ifrågasätts skall denne entledigas från ärendet och ersättas enligt §[4.7] Vakanta poster i Trygghetsrådet
 
-- vid situation där en eller flera medlemmar i Trygghetsrådet ej kan agera objektivt skall denne eller dessa entledigas från ärendet och ersättas enligt $[4.7] Vakanta poster i Trygghetsrådet
+- vid situation där en eller flera medlemmar i Trygghetsrådet ej kan agera objektivt skall denne eller dessa entledigas från ärendet och ersättas enligt §[4.7] Vakanta poster i Trygghetsrådet
 
 	- I de fall där det inte är möjligt att tillsätta tillräckligt många objektiva styrelseledamöter ska utredningen istället lämnas över till högre instans inom KTH eller THS.
 
@@ -121,7 +121,7 @@ Anmälan av händelse eller allmän kontakt till Skyddsombud kan göras genom f�
 
 Med målsägandens samtycke, och efter diskussion om tystnadsplikt, kan Skyddsombuden ta ärendet vidare till Trygghetsrådet. Målsägande kan när som helst välja att avsluta utredningen.
 
-Anmälan av person inom Trygghetsrådet görs enligt $[4.6] Vid utredning av medlem i Trygghetsrådet.
+Anmälan av person inom Trygghetsrådet görs enligt §[4.6] Vid utredning av medlem i Trygghetsrådet.
 
 Anmälan gällande händelse inom, med Sektionen för Medieteknik, delad verksamhet utreds i samråd med motsvarande utredande instans på Sektionen för Medieteknik.
 

--- a/reglemente/body_sv.md
+++ b/reglemente/body_sv.md
@@ -398,7 +398,7 @@ Vid urnval röstar man genom att rangordna alla alternativ i valet, där vakans 
 
 Om fler än ett mandat ska fördelas med samma urnval så sker detta i nedstigande ordning enligt den rangordning som producerats av rösträkningen. Om även mandat för suppleanter, vice eller liknande ska delas ut i samma val så sker detta i nedstigande ordning enligt samma rangordning, bland de kandidater som inte blev tilldelade ett ordinarie mandat. Om flera kandidater skulle vara lika rangordnade avgörs deras ordning genom slump.
 
-Resultat av urnval ska godkännas av SM enligt stadgarnas §[1.7](../stadgar#1-7-beslutsnivåer).
+Resultat av urnval ska godkännas av SM enligt stadgarnas §[1.8](../stadgar#1-8-beslutsnivåer).
 
 Kandidater som ställer upp i urnval får inte vara inblandade i administrationen av urnvalsprocessen.
 
@@ -430,7 +430,7 @@ Då urnval anordnats ska även information om hur urnvalets röstprocess gått t
 
 #### §5.12.8.2 Publiceringsplats
 
-Valhandlingarna ska publiceras via officiella informationskanaler enligt Stadgarnas §[1.8](../stadgar#1-8-officiella-informationskanaler).
+Valhandlingarna ska publiceras via officiella informationskanaler enligt Stadgarnas §[1.9](../stadgar#1-9-officiella-informationskanaler).
 
 #### §5.12.8.3 Publiceringstid
 

--- a/stadgar/body_sv.md
+++ b/stadgar/body_sv.md
@@ -176,7 +176,7 @@ Det åligger SM att
 
 -   om sektionsmedlem så önskar granska protokoll från DM
 
--   välja funktionärer, med undantag av de som har avvikande valprocesser enligt §3.13.6
+-   välja funktionärer, med undantag av de som har avvikande valprocesser enligt §[3.13.7]
 
 -   genomföra fyllnadsval vid behov, även till poster som vanligen väljs vid urnval.
 
@@ -463,6 +463,7 @@ Sektionens verksamhetsberättelse och årsbokslut ska överlämnas till revisore
 [3.10]: #3-10-ordinarie-sm
 [3.12]: #3-12-ajournering
 [3.13.2]: #3-13-2-nomineringar
+[3.13.7]: #3-13-7-avvikande-valprocesser
 [4.2.1]: #4-2-1-kallelse
 [5.2]: #5-2-kallelse
 [5.8]: #5-8-ajournering

--- a/stadgar/body_sv.md
+++ b/stadgar/body_sv.md
@@ -64,7 +64,7 @@ Stadgarna ändras genom likalydande beslut på två på varandra följande SM, v
 
 ### §1.7.5 Dispens från stadgarna
 
-Dispens från bestämmelse i dessa stadgar kan beviljas om SM enhälligt beslutar så. Dispens får dock ej medges från §[1.1] – §[1.6] och ej heller om det är till nackdel för enskild sektionsmedlem. Beslut om dispens ska motiveras i mötesprotokollet.
+Dispens från bestämmelse i dessa stadgar kan beviljas om SM enhälligt beslutar så. Dispens får dock ej medges från §[1.1] – §[1.7] och ej heller om det är till nackdel för enskild sektionsmedlem. Beslut om dispens ska motiveras i mötesprotokollet.
 
 ### §1.7.6 Föreskrifter utöver stadgarna
 
@@ -184,15 +184,15 @@ Det åligger SM att
 
 D-rektoratet kallar till ordinarie och extra SM.
 
-Kallelse till ordinarie SM ska anslås enligt §[1.8] samt tillsändas THS styrelse, THS sakrevisorer och skolans kansli senast 35 dagar före mötet för att mötet ska anses vara behörigt utlyst.
+Kallelse till ordinarie SM ska anslås enligt §[1.9] samt tillsändas THS styrelse, THS sakrevisorer och skolans kansli senast 35 dagar före mötet för att mötet ska anses vara behörigt utlyst.
 
-Kallelse till extra SM ska anslås enligt §[1.8] samt tillsändas THS styrelse och THS sakrevisorer senast 11 dagar före mötet för att mötet ska anses vara behörigt utlyst.
+Kallelse till extra SM ska anslås enligt §[1.9] samt tillsändas THS styrelse och THS sakrevisorer senast 11 dagar före mötet för att mötet ska anses vara behörigt utlyst.
 
 Föredragningslista och övriga handlingar ska anslås jämte kallelse senast 7 dagar före mötet. Föredragningslistan och övriga handlingar kan kompletteras för att lägga till sent inkomna ärenden eller ändra ordningen av föredragningslistan. Kompletterande handlingar ska anslås jämte kallelsen senast 3 dagar före mötet.
 
 Om minst 30 sektionsmedlemmar, sektionsrevisor enligt §[10.1] eller THS styrelse så begär hos D-rektoratet, ska extra SM hållas inom 28 dagar.
 
-Kallelse ska innehålla tid och lokal för mötet samt även information om en reservtid där mötet återupptas om ajournering beslutas enligt §[3.12]. Reservtiden ska vara senast 7 dagar efter den ordinarie tiden för mötet. Om sektionsmötet ajourneras till reservtiden så ska en lokal för mötets reservtid utses. Ifall lokalen för mötet av någon anledning skulle vara otillgänglig vid tiden för mötet kan en ny lokal utses. Information om ändrad lokal och/eller lokal för reservtid ska anslås enligt §[1.8], samt tillsändas samma instanser som kallelsen senast vid mötets starttid respektive återupptagande.
+Kallelse ska innehålla tid och lokal för mötet samt även information om en reservtid där mötet återupptas om ajournering beslutas enligt §[3.12]. Reservtiden ska vara senast 7 dagar efter den ordinarie tiden för mötet. Om sektionsmötet ajourneras till reservtiden så ska en lokal för mötets reservtid utses. Ifall lokalen för mötet av någon anledning skulle vara otillgänglig vid tiden för mötet kan en ny lokal utses. Information om ändrad lokal och/eller lokal för reservtid ska anslås enligt §[1.9], samt tillsändas samma instanser som kallelsen senast vid mötets starttid respektive återupptagande.
 
 ## §3.4 Beslutsmässighet
 
@@ -210,7 +210,7 @@ Varje röstberättigad deltagare på SM kan reservera sig mot fattat beslut. Res
 
 ## §3.7 Protokoll
 
-Vid SM ska diskussionsprotokoll föras av mötessekreterare och justeras av mötesordföranden jämte två av mötet utsedda justerare. Protokoll ska i justerat skick anslås enligt §[1.8] inom 14 dagar, samt på begäran
+Vid SM ska diskussionsprotokoll föras av mötessekreterare och justeras av mötesordföranden jämte två av mötet utsedda justerare. Protokoll ska i justerat skick anslås enligt §[1.9] inom 14 dagar, samt på begäran
 tillsändas THS styrelse.
 
 ## §3.8 Interpellation, motion och proposition
@@ -252,7 +252,7 @@ Sektionens val ska beredas av Valberedningen. Valberedningens arbete och sammans
 
 ### §3.13.1 Nomineringar
 
-Valberedningen ska i samband med val anslå en nomineringslista via officiella informationskanaler enligt §[1.8]. På denna lista kan sektionsmedlemmar nomineras till funktionärsposter, dock ska det även vara möjligt att maila nomineringar till Valberedningen.
+Valberedningen ska i samband med val anslå en nomineringslista via officiella informationskanaler enligt §[1.9]. På denna lista kan sektionsmedlemmar nomineras till funktionärsposter, dock ska det även vara möjligt att maila nomineringar till Valberedningen.
 
 Valberedningen ska tillfråga de nominerade huruvida de vill acceptera nomineringen. Samtidigt som nomineringslistan anslås ska Valberedningen även anslå en lista på samtliga nominerade i valet.
 
@@ -310,7 +310,7 @@ Dessa har närvaro-, yttrande-, yrkande- och rösträtt vid DM. Sektionens revis
 
 ### §4.2.1 Kallelse
 
-Styrelsen kallar till D-rektoratsmöte, DM. Kallelsen ska anslås enligt §[1.8] samt skickas med e-post till D-rektoratets ledamöter och sektionens funktionärer senast 7 dagar före mötet.
+Styrelsen kallar till D-rektoratsmöte, DM. Kallelsen ska anslås enligt §[1.9] samt skickas med e-post till D-rektoratets ledamöter och sektionens funktionärer senast 7 dagar före mötet.
 
 Föredragningslista och övriga handlingar ska anslås senast 1 dag innan DM. Kompletterande handlingar kan skickas ut samma dag som mötet hålls.
 
@@ -320,7 +320,7 @@ DM är beslutsmässigt om minst hälften av dess ledamöter är närvarande, och
 
 ### §4.2.3 Protokoll
 
-På DM ska protokoll föras. Protokollet ska justeras av mötesordföranden jämte en av mötet utsedd justerare. Protokollet ska anslås enligt §[1.8] i justerat skick senast 21 dagar efter mötet.
+På DM ska protokoll föras. Protokollet ska justeras av mötesordföranden jämte en av mötet utsedd justerare. Protokollet ska anslås enligt §[1.9] i justerat skick senast 21 dagar efter mötet.
 
 ## §4.3 Uppgifter
 
@@ -360,7 +360,7 @@ Om Kassör är oförmögen att utföra sina ansvarsområden utövar Vice kassör
 
 ## §4.8 Per capsulam-beslut
 
-Vid per capsulam beslut gäller 2/3-majoritet och att beslut informeras om, samt, efter förfrågan från sektionsmedlem, prövas på nästkommande DM. D-rektoratet ska kontakta revisorerna med information om beslutet som tagits. Vid utövande av SM:s befogenheter ska information om beslutet också anslås enligt §[1.8].
+Vid per capsulam beslut gäller 2/3-majoritet och att beslut informeras om, samt, efter förfrågan från sektionsmedlem, prövas på nästkommande DM. D-rektoratet ska kontakta revisorerna med information om beslutet som tagits. Vid utövande av SM:s befogenheter ska information om beslutet också anslås enligt §[1.9].
 
 ## §4.9 D-rektiv
 
@@ -376,11 +376,11 @@ Hedersmedlemmar, alumnimedlemmar och ledamöter i THS styrelse har närvaro- och
 
 ## §5.2 Kallelse
 
-D-rektoratet kallar till valmöte, VM. Kallelsen ska anslås enligt stadgarna §[1.8] senast 21 dagar före mötet.
+D-rektoratet kallar till valmöte, VM. Kallelsen ska anslås enligt stadgarna §[1.9] senast 21 dagar före mötet.
 
 Föredragningslista och övriga handlingar ska anslås jämte kallelse senast 7 dagar innan VM. Kompletterande handlingar kan skickas ut senast 1 dag innan aviserad mötestid.
 
-Kallelse ska innehålla tid och lokal för mötet samt även information om en reservtid och lokal där mötet återupptas om ajournering beslutas enligt §[5.8]. Reservtiden ska vara senast 7 dagar efter den ordinarie tiden för mötet. Ifall lokalen för mötet och/eller lokalen för reservtiden av någon anledning skulle vara otillgänglig vid tiden för mötet kan en ny lokal utses. Information om detta ska då anslås enligt §[1.8], samt tillsändas samma instanser som kallelsen senast vid mötets starttid respektive återupptagande.
+Kallelse ska innehålla tid och lokal för mötet samt även information om en reservtid och lokal där mötet återupptas om ajournering beslutas enligt §[5.8]. Reservtiden ska vara senast 7 dagar efter den ordinarie tiden för mötet. Ifall lokalen för mötet och/eller lokalen för reservtiden av någon anledning skulle vara otillgänglig vid tiden för mötet kan en ny lokal utses. Information om detta ska då anslås enligt §[1.9], samt tillsändas samma instanser som kallelsen senast vid mötets starttid respektive återupptagande.
 
 ## §5.3 Beslutsmässighet
 
@@ -392,7 +392,7 @@ Beslut fattas med enkel majoritet såvida inget annat stadgats. Vid lika röstet
 
 ## §5.5 Protokoll
 
-På VM ska protokoll föras. Protokollet ska justeras av mötesordföranden jämte en av mötet utsedd justerare. Protokollet ska anslås enligt stadgarna §[1.8] i justerat skick senast 7 dagar efter mötet.
+På VM ska protokoll föras. Protokollet ska justeras av mötesordföranden jämte en av mötet utsedd justerare. Protokollet ska anslås enligt stadgarna §[1.9] i justerat skick senast 7 dagar efter mötet.
 
 ## §5.6 Sammanträden
 
@@ -434,7 +434,7 @@ Det åligger revisorerna att
 
 -   fortlöpande granska sektionens förvaltning och verksamhet
 
--   senast 7 dagar före de SM vid vilka fråga om ansvarsfrihet behandlas anslå revisionberättelse enligt §[1.8] samt inlämna revisionberättelse till D-rektoratet.
+-   senast 7 dagar före de SM vid vilka fråga om ansvarsfrihet behandlas anslå revisionberättelse enligt §[1.9] samt inlämna revisionberättelse till D-rektoratet.
 
 ### §6.1.3 Revisionssed
 
@@ -448,11 +448,11 @@ Revisorerna är skyldiga att inte
 
 ## §6.2 Verksamhetsberättelse och årsbokslut
 
-Sektionens verksamhetsberättelse och årsbokslut ska överlämnas till revisorerna senast 21 dagar före det SM på vilka de ska granskas, samt anslås enligt §[1.8] senast 14 dagar före samma SM.
+Sektionens verksamhetsberättelse och årsbokslut ska överlämnas till revisorerna senast 21 dagar före det SM på vilka de ska granskas, samt anslås enligt §[1.9] senast 14 dagar före samma SM.
 
 [1.1]: #1-1-namn
-[1.6]: #1-6-styrdokument
-[1.8]: #1-8-officiella-informationskanaler
+[1.7]: #1-7-styrdokument
+[1.9]: #1-9-officiella-informationskanaler
 [2]: #2-medlemskap
 [2.1]: #2-1-ordinarie-sektionsmedlem
 [2.2]: #2-2-hedersmedlem

--- a/stadgar/body_sv.md
+++ b/stadgar/body_sv.md
@@ -246,37 +246,37 @@ Vilka ansvarsposter som väljs via val definieras i reglementet. Dessa benämns 
 
 Om inget annat är föreskrivet så väljs funktionärer via den ordinarie valprocessen.
 
-### 3.13.1 Valberedningen
+### §3.13.1 Valberedningen
 
 Sektionens val ska beredas av Valberedningen. Valberedningens arbete och sammansättning definieras vidare i reglementet.
 
-### §3.13.1 Nomineringar
+### §3.13.2 Nomineringar
 
 Valberedningen ska i samband med val anslå en nomineringslista via officiella informationskanaler enligt §[1.9]. På denna lista kan sektionsmedlemmar nomineras till funktionärsposter, dock ska det även vara möjligt att maila nomineringar till Valberedningen.
 
 Valberedningen ska tillfråga de nominerade huruvida de vill acceptera nomineringen. Samtidigt som nomineringslistan anslås ska Valberedningen även anslå en lista på samtliga nominerade i valet.
 
-### §3.13.2 Ordinarie val
+### §3.13.3 Ordinarie val
 
 Nomineringslistan ska anslås enligt §[3.13.1] senast 35 dagar före SM då ordinarie val sker. Nominering till funktionärspost måste lämnas in senast 21 dagar före det SM där valet sker. Nominering till funktionärspost måste accepteras senast 14 dagar före det SM där valet sker för att kandidaturen ska vara giltig.
 
 Om inga nomineringar lämnats in vid sista nomineringsdag kan Valberedningens ordförande flytta fram nomineringsstopp samt acceptansstopp 7 dagar för den specifika posten. I händelse att det finns färre kandidater än antalet som ska väljas efter acceptansstopp ska Valberedningens ordförande ha möjlighet att öppna upp ytterligare en nomineringsperiod för den givna posten på 7 dagar och därefter ska acceptansstoppet vara 1 dag innan SM. Detta gäller inte Ordförande, Vice ordförande, Kassör samt Kårfullmäktigeledamöter och -suppleanter för att möjliggöra urnval.
 
-### §3.13.3 Fyllnadsval
+### §3.13.4 Fyllnadsval
 
 Om en funktionärspost blir vakantsatt ska Valberedningen lysa fyllnadsval till nästkommande SM.
 
 Inför fyllnadsval ska nomineringslistan anslås enligt §[3.13.1] senast 21 dagar före det SM då fyllnadsvalet sker. Nominering till funktionärspost måste lämnas in senast 7 dagar före det SM där fyllnadsvalet sker. Nominering till funktionärspost måste accepteras senast 1 dag före det SM där fyllnadsvalet sker för att kandidaturen ska vara giltig.
 
-### §3.13.4 Val vid extra SM
+### §3.13.5 Val vid extra SM
 
 Nomineringslistan ska anslås enligt §[3.13.1] senast 11 dagar före det extra SM då ett val sker. Nominering till funktionärspost måste lämnas in senast 1 dag före det extra SM där valet sker. Nominering till funktionärspost måste accepteras innan öppnandet av det extra SM där valet sker för att kandidaturen ska vara giltig.
 
-### §3.13.5 Kandidatur under SM
+### §3.13.6 Kandidatur under SM
 
 Då ingen kandidat finns till en post under sektionsmöte vartill val till posten lysts, kan SM besluta att öppna för fri kandidatur. Vid val av kandidat under ovanstående omständigheter krävs ett beslut med 3/4-majoritet av SM.
 
-### §3.13.6 Avvikande valprocesser
+### §3.13.7 Avvikande valprocesser
 
 Ordförande, Vice ordförande, Kassör, Vice kassör samt Kårfullmäktigeledamöter och -suppleanter väljs med urnval i enlighet med reglementet.
 

--- a/stadgar/body_sv.md
+++ b/stadgar/body_sv.md
@@ -258,7 +258,7 @@ Valberedningen ska tillfråga de nominerade huruvida de vill acceptera nominerin
 
 ### §3.13.3 Ordinarie val
 
-Nomineringslistan ska anslås enligt §[3.13.1] senast 35 dagar före SM då ordinarie val sker. Nominering till funktionärspost måste lämnas in senast 21 dagar före det SM där valet sker. Nominering till funktionärspost måste accepteras senast 14 dagar före det SM där valet sker för att kandidaturen ska vara giltig.
+Nomineringslistan ska anslås enligt §[3.13.2] senast 35 dagar före SM då ordinarie val sker. Nominering till funktionärspost måste lämnas in senast 21 dagar före det SM där valet sker. Nominering till funktionärspost måste accepteras senast 14 dagar före det SM där valet sker för att kandidaturen ska vara giltig.
 
 Om inga nomineringar lämnats in vid sista nomineringsdag kan Valberedningens ordförande flytta fram nomineringsstopp samt acceptansstopp 7 dagar för den specifika posten. I händelse att det finns färre kandidater än antalet som ska väljas efter acceptansstopp ska Valberedningens ordförande ha möjlighet att öppna upp ytterligare en nomineringsperiod för den givna posten på 7 dagar och därefter ska acceptansstoppet vara 1 dag innan SM. Detta gäller inte Ordförande, Vice ordförande, Kassör samt Kårfullmäktigeledamöter och -suppleanter för att möjliggöra urnval.
 
@@ -266,11 +266,11 @@ Om inga nomineringar lämnats in vid sista nomineringsdag kan Valberedningens or
 
 Om en funktionärspost blir vakantsatt ska Valberedningen lysa fyllnadsval till nästkommande SM.
 
-Inför fyllnadsval ska nomineringslistan anslås enligt §[3.13.1] senast 21 dagar före det SM då fyllnadsvalet sker. Nominering till funktionärspost måste lämnas in senast 7 dagar före det SM där fyllnadsvalet sker. Nominering till funktionärspost måste accepteras senast 1 dag före det SM där fyllnadsvalet sker för att kandidaturen ska vara giltig.
+Inför fyllnadsval ska nomineringslistan anslås enligt §[3.13.2] senast 21 dagar före det SM då fyllnadsvalet sker. Nominering till funktionärspost måste lämnas in senast 7 dagar före det SM där fyllnadsvalet sker. Nominering till funktionärspost måste accepteras senast 1 dag före det SM där fyllnadsvalet sker för att kandidaturen ska vara giltig.
 
 ### §3.13.5 Val vid extra SM
 
-Nomineringslistan ska anslås enligt §[3.13.1] senast 11 dagar före det extra SM då ett val sker. Nominering till funktionärspost måste lämnas in senast 1 dag före det extra SM där valet sker. Nominering till funktionärspost måste accepteras innan öppnandet av det extra SM där valet sker för att kandidaturen ska vara giltig.
+Nomineringslistan ska anslås enligt §[3.13.2] senast 11 dagar före det extra SM då ett val sker. Nominering till funktionärspost måste lämnas in senast 1 dag före det extra SM där valet sker. Nominering till funktionärspost måste accepteras innan öppnandet av det extra SM där valet sker för att kandidaturen ska vara giltig.
 
 ### §3.13.6 Kandidatur under SM
 
@@ -400,7 +400,7 @@ Det ska förekomma maximalt ett VM per period. VM får inte hållas under tentam
 
 ## §5.7 Val
 
-Nomineringslistan ska anslås enligt stadgarnas §[3.13.1] senast 21 dagar före VM. Nominering till funktionärspost måste lämnas in senast 14 dagar före det VM där valet sker. Nominering till funktionärspost måste accepteras senast 10 dagar före det VM där valet sker för att kandidaturen ska vara giltig.
+Nomineringslistan ska anslås enligt stadgarnas §[3.13.2] senast 21 dagar före VM. Nominering till funktionärspost måste lämnas in senast 14 dagar före det VM där valet sker. Nominering till funktionärspost måste accepteras senast 10 dagar före det VM där valet sker för att kandidaturen ska vara giltig.
 
 Om inga nomineringar lämnats in vid sista nomineringsdag kan Valberedningens ordförande flytta fram nomineringsstopp samt acceptansstopp 3 dagar för den specifika posten. I händelse att det finns färre kandidater än antalet som ska väljas efter acceptansstopp ska Valberedningens ordförande ha möjlighet att öppna upp ytterligare en nomineringsperiod för den givna posten på 5 dagar och därefter ska acceptansstoppet vara 1 dag innan VM.
 
@@ -462,7 +462,7 @@ Sektionens verksamhetsberättelse och årsbokslut ska överlämnas till revisore
 [3.3]: #3-3-kallelse
 [3.10]: #3-10-ordinarie-sm
 [3.12]: #3-12-ajournering
-[3.13.1]: #3-13-1-nomineringar
+[3.13.2]: #3-13-2-nomineringar
 [4.2.1]: #4-2-1-kallelse
 [5.2]: #5-2-kallelse
 [5.8]: #5-8-ajournering


### PR DESCRIPTION
Löser problem med konsekvensnumrering och pekarreferenser i #339. Jag anser att det är en del av konsekvensnumreringen.

De tre commit:sen 41df2cd0933d4612470df2073a631d72e82e919a, 8fe407f6d19fd6ba850b9946bf5d459298eb872d samt dfb8c81c9b3620db04d1ea60774dc5172740af4d är mest najs redaktionella tolkningar att ha och ger pekare i alla PMs samt rätt tecken § istället för fel $.

Kom gärna med tycke om några ändringar är för grova.